### PR TITLE
Feature/2.2/handle connection disabled enabled

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,9 @@ allprojects{
     targetCompatibility = "8"
     options.compilerArgs << "-Xlint:all" << "-Werror"
   }
-  repositories {
-    mavenCentral()
+    repositories {
+	mavenCentral()
+	maven {url 'https://s01.oss.sonatype.org/content/repositories/snapshots' }
   }
 }
 

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoriesByPriority.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoriesByPriority.java
@@ -23,7 +23,6 @@ public class ConnectionFactoriesByPriority
 {
     private final Map<Long, List<ConnectionFactoryEntry>> mapping = new ConcurrentHashMap<>();
     private final Set<String> checkedConnectionFactories = new HashSet<>();
-    private final Set<String> foundConnectionFactories = new HashSet<>();
 
     private ConnectionFactoriesByPriority()
     {
@@ -64,7 +63,6 @@ public class ConnectionFactoriesByPriority
         if (!serviceDetails.isEmpty())
         {
             checkedConnectionFactories.add(entry.getJndiName());
-            foundConnectionFactories.add(entry.getJndiName());
             serviceDetails
                     .forEach(discoveryDetails ->
                     {
@@ -91,7 +89,6 @@ public class ConnectionFactoriesByPriority
         // Add missing connection factories for this service and priority
         for (ConnectionFactoryEntry entry : entries)
         {
-            foundConnectionFactories.add(entry.getJndiName());
             if (!listForPriority.contains(entry))
             {
                 listForPriority.add(entry);
@@ -183,7 +180,6 @@ public class ConnectionFactoriesByPriority
 
     public void remove(ConnectionFactoryEntry connectionFactoryEntry)
     {
-        foundConnectionFactories.remove(connectionFactoryEntry.getJndiName());
         checkedConnectionFactories.remove(connectionFactoryEntry.getJndiName());
         for(Map.Entry<Long, List<ConnectionFactoryEntry>> entry : mapping.entrySet())
         {

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryEntry.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryEntry.java
@@ -19,7 +19,6 @@ public class ConnectionFactoryEntry implements ConnectionListener
 {
     private static final Logger LOG = Logger.getLogger(ConnectionFactoryEntry.class.getName());
     private final ConnectionFactoryProducer connectionFactoryProducer;
-    private final AtomicBoolean connectionListenerAdded = new AtomicBoolean(false);
     private final AtomicBoolean connectionEnabled = new AtomicBoolean(true);
     /**
      * Connection factory entries should invalidate on connection errors and revalidate as soon as a new valid
@@ -75,7 +74,7 @@ public class ConnectionFactoryEntry implements ConnectionListener
     {
         try(CasualConnection con = getConnectionFactory().getConnection())
         {
-            maybeAddConnectionListener(con);
+            con.addListener(this);
             // We just want to check that a connection could be established to check connectivity
             valid = true;
             LOG.finest(() -> "Successfully validated CasualConnection with jndiName=" + connectionFactoryProducer.getJndiName());
@@ -106,8 +105,7 @@ public class ConnectionFactoryEntry implements ConnectionListener
     @Override
     public int hashCode()
     {
-        // TODO: why is isValid in hashCode?
-        return Objects.hash(connectionFactoryProducer, isValid());
+        return Objects.hash(connectionFactoryProducer);
     }
 
     @Override
@@ -123,22 +121,12 @@ public class ConnectionFactoryEntry implements ConnectionListener
     @Override
     public void connectionDisabled()
     {
-        connectionEnabled.set(true);
+        connectionEnabled.set(false);
     }
 
     @Override
     public void connectionEnabled()
     {
-        connectionEnabled.set(false);
-    }
-
-    private void maybeAddConnectionListener(CasualConnection connection)
-    {
-        if(connectionListenerAdded.get())
-        {
-            return;
-        }
-        connection.addListener(this);
-        connectionListenerAdded.set(true);
+        connectionEnabled.set(true);
     }
 }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryEntry.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryEntry.java
@@ -139,5 +139,6 @@ public class ConnectionFactoryEntry implements ConnectionListener
             return;
         }
         connection.addListener(this);
+        connectionListenerAdded.set(true);
     }
 }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryProducer.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryProducer.java
@@ -16,9 +16,11 @@ public class ConnectionFactoryProducer
 {
 
     private final String jndiName;
+
     private ConnectionFactoryProducer(String jndiName)
     {
         this.jndiName = jndiName;
+
     }
 
     public static ConnectionFactoryProducer of(String jndiName)
@@ -73,4 +75,5 @@ public class ConnectionFactoryProducer
                 "jndiName='" + jndiName + '\'' +
                 '}';
     }
+
 }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryProducer.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryProducer.java
@@ -16,11 +16,9 @@ public class ConnectionFactoryProducer
 {
 
     private final String jndiName;
-
     private ConnectionFactoryProducer(String jndiName)
     {
         this.jndiName = jndiName;
-
     }
 
     public static ConnectionFactoryProducer of(String jndiName)
@@ -75,5 +73,4 @@ public class ConnectionFactoryProducer
                 "jndiName='" + jndiName + '\'' +
                 '}';
     }
-
 }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/util/ConnectionFactoryFinder.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/util/ConnectionFactoryFinder.java
@@ -5,8 +5,8 @@
  */
 package se.laz.casual.connection.caller.util;
 
-import se.laz.casual.connection.caller.ConnectionFactoryProducer;
 import se.laz.casual.connection.caller.ConnectionFactoryEntry;
+import se.laz.casual.connection.caller.ConnectionFactoryProducer;
 import se.laz.casual.jca.CasualConnectionFactory;
 
 import javax.naming.InitialContext;
@@ -16,6 +16,7 @@ import javax.naming.NamingException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 import java.util.logging.Logger;
 
 public class ConnectionFactoryFinder
@@ -36,7 +37,7 @@ public class ConnectionFactoryFinder
         try
         {
             InitialContext ctx = new InitialContext();
-            return findConnectionFactory(root, ctx);
+            return findConnectionFactory(root, ctx, ConnectionFactoryProducer::of);
         }
         catch (NamingException e)
         {
@@ -45,7 +46,7 @@ public class ConnectionFactoryFinder
         return Collections.<ConnectionFactoryEntry>emptyList();
     }
 
-    public List<ConnectionFactoryEntry> findConnectionFactory(String root, InitialContext context)
+    public List<ConnectionFactoryEntry> findConnectionFactory(String root, InitialContext context, Function<String, ConnectionFactoryProducer> producerFunction)
     {
         try
         {
@@ -58,7 +59,7 @@ public class ConnectionFactoryFinder
                 Object instance = context.lookup(jndiName);
                 if(instance instanceof CasualConnectionFactory)
                 {
-                    foundEntries.add(ConnectionFactoryEntry.of(ConnectionFactoryProducer.of(jndiName)));
+                    foundEntries.add(ConnectionFactoryEntry.of(producerFunction.apply(jndiName)));
                     log.info(() -> "found casual connection factory with JNDI-name: " + jndiName);
                 }
             }

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/CacheTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/CacheTest.groovy
@@ -10,6 +10,7 @@ import se.laz.casual.api.discovery.DiscoveryReturn
 import se.laz.casual.api.queue.QueueDetails
 import se.laz.casual.api.queue.QueueInfo
 import se.laz.casual.api.service.ServiceDetails
+import se.laz.casual.jca.CasualConnection
 import se.laz.casual.jca.CasualConnectionFactory
 import se.laz.casual.network.messages.domain.TransactionType
 import spock.lang.Shared
@@ -22,11 +23,15 @@ class CacheTest extends Specification
    @Shared
    Cache instance
    @Shared
-   def connectionFactoryOne = Mock(CasualConnectionFactory)
+   def connectionFactoryOne = Mock(CasualConnectionFactory){
+      getConnection() >> Mock(CasualConnection)
+   }
    @Shared
    def jndiNameOne = 'eis/CasualConnectionFactory'
    @Shared
-   def connectionFactoryTwo = Mock(CasualConnectionFactory)
+   def connectionFactoryTwo = Mock(CasualConnectionFactory){
+      getConnection() >> Mock(CasualConnection)
+   }
    @Shared
    def jndiNameTwo = 'eis/AnotherCasualConnectionFactory'
    @Shared

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/ConnectionFactoryLookupServiceTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/ConnectionFactoryLookupServiceTest.groovy
@@ -33,27 +33,10 @@ class ConnectionFactoryLookupServiceTest extends Specification
     @Shared
     CasualConnectionFactory conFacTwo
     @Shared
-    ConnectionFactoryProducer producerOne = {
-       def mock = Mock(ConnectionFactoryProducer)
-       mock.getConnectionFactory() >> {
-          conFac
-       }
-      mock.getJndiName() >> {
-         jndiNameConFactoryOne
-      }
-      return mock
-    }()
+    ConnectionFactoryProducer producerOne
+
     @Shared
-    ConnectionFactoryProducer producerTwo = {
-       def mock = Mock(ConnectionFactoryProducer)
-       mock.getConnectionFactory() >> {
-          conFacTwo
-       }
-       mock.getJndiName() >> {
-          jndiNameConFactoryTwo
-       }
-       return mock
-    }()
+    ConnectionFactoryProducer producerTwo
 
     @Shared
     def env = new HashMap()
@@ -87,9 +70,32 @@ class ConnectionFactoryLookupServiceTest extends Specification
         conFacHigh.getConnection() >> conHigh
         conFacLow.getConnection() >> conLow
 
-        conFac = Mock(CasualConnectionFactory)
-        conFacTwo = Mock(CasualConnectionFactory)
+        conFac = Mock(CasualConnectionFactory) {
+           getConnection() >> conHigh
+        }
+        conFacTwo = Mock(CasualConnectionFactory) {
+           getConnection() >> conLow
+        }
         connnectionFactoryProvider = Mock(ConnectionFactoryEntryStore)
+
+        producerOne = Mock(ConnectionFactoryProducer) {
+           getConnectionFactory() >> {
+              conFac
+           }
+           getJndiName() >> {
+              jndiNameConFactoryOne
+           }
+        }
+
+        producerTwo = Mock(ConnectionFactoryProducer) {
+           getConnectionFactory() >> {
+              conFacTwo
+           }
+           getJndiName() >> {
+              jndiNameConFactoryTwo
+           }
+        }
+
         cache =  new Cache()
         lookup = Mock(Lookup)
         instance = new ConnectionFactoryLookupService()
@@ -98,7 +104,7 @@ class ConnectionFactoryLookupServiceTest extends Specification
         instance.lookup = lookup
     }
 
-    def 'asssert basic sanity'()
+    def 'assert basic sanity'()
     {
         given:
         connnectionFactoryProvider.get() >> {
@@ -224,10 +230,18 @@ class ConnectionFactoryLookupServiceTest extends Specification
     def "priority is descending"()
     {
         setup:
-        def conFac1 = Mock(CasualConnectionFactory)
-        def conFac2 = Mock(CasualConnectionFactory)
-        def conFac3 = Mock(CasualConnectionFactory)
-        def conFac4 = Mock(CasualConnectionFactory)
+        def conFac1 = Mock(CasualConnectionFactory) {
+           getConnection() >> Mock(CasualConnection)
+        }
+        def conFac2 = Mock(CasualConnectionFactory) {
+           getConnection() >> Mock(CasualConnection)
+        }
+        def conFac3 = Mock(CasualConnectionFactory) {
+           getConnection() >> Mock(CasualConnection)
+        }
+        def conFac4 = Mock(CasualConnectionFactory) {
+           getConnection() >> Mock(CasualConnection)
+        }
 
         def conFac1Name = "name1"
         def conFac2Name = "name2"

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/RandomEntryTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/RandomEntryTest.groovy
@@ -1,6 +1,8 @@
 package se.laz.casual.connection.caller
 
 import se.laz.casual.api.queue.QueueInfo
+import se.laz.casual.jca.CasualConnection
+import se.laz.casual.jca.CasualConnectionFactory
 import spock.lang.Specification
 
 class RandomEntryTest extends Specification
@@ -39,7 +41,12 @@ class RandomEntryTest extends Specification
     {
         given:
         def serviceName = 'echo'
-        def entries = [ConnectionFactoryEntry.of(Mock(ConnectionFactoryProducer))]
+        def connectionFactory = Mock(CasualConnectionFactory){
+           getConnection() >> Mock(CasualConnection)
+        }
+        def entries = [ConnectionFactoryEntry.of(Mock(ConnectionFactoryProducer){
+           getConnectionFactory() >> connectionFactory
+        })]
         def lookup = Mock(ConnectionFactoryLookup)
         lookup.get(serviceName) >> {
             entries
@@ -54,7 +61,12 @@ class RandomEntryTest extends Specification
     {
         given:
         def queueInfo = QueueInfo.of('Battlestar.Galactica')
-        def entry = Optional.of(ConnectionFactoryEntry.of(Mock(ConnectionFactoryProducer)))
+        def connectionFactory = Mock(CasualConnectionFactory){
+           getConnection() >> Mock(CasualConnection)
+        }
+        def entry = Optional.of(ConnectionFactoryEntry.of(Mock(ConnectionFactoryProducer){
+           getConnectionFactory() >> connectionFactory
+        }))
         def lookup = Mock(ConnectionFactoryLookup)
         lookup.get(queueInfo) >> {
             entry
@@ -68,9 +80,18 @@ class RandomEntryTest extends Specification
     def 'getEntry with more than 1 entry should get all entries eventually'()
     {
         given:
-        def entryOne = ConnectionFactoryEntry.of(Mock(ConnectionFactoryProducer))
-        def entryTwo = ConnectionFactoryEntry.of(Mock(ConnectionFactoryProducer))
-        def entryThree = ConnectionFactoryEntry.of(Mock(ConnectionFactoryProducer))
+        def connectionFactory = Mock(CasualConnectionFactory){
+           getConnection() >> Mock(CasualConnection)
+        }
+        def entryOne = ConnectionFactoryEntry.of(Mock(ConnectionFactoryProducer){
+           getConnectionFactory() >> connectionFactory
+        })
+        def entryTwo = ConnectionFactoryEntry.of(Mock(ConnectionFactoryProducer){
+           getConnectionFactory() >> connectionFactory
+        })
+        def entryThree = ConnectionFactoryEntry.of(Mock(ConnectionFactoryProducer){
+           getConnectionFactory() >> connectionFactory
+        })
         def cachedEntries = [entryOne, entryTwo, entryThree]
         def possibleEntries = [entryOne, entryTwo, entryThree]
         when:

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,9 +7,9 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '2.2.9'
+version = '2.2.10'
 
-def casual_jca_version = '2.2.20'
+def casual_jca_version = '2.2.22-3-SNAPSHOT'
 def gson_version = '2.10.1'
 
 ext.libs = [

--- a/versions.gradle
+++ b/versions.gradle
@@ -9,7 +9,7 @@
 group = 'se.laz.casual'
 version = '2.2.10'
 
-def casual_jca_version = '2.2.22-3-SNAPSHOT'
+def casual_jca_version = '2.2.22'
 def gson_version = '2.10.1'
 
 ext.libs = [


### PR DESCRIPTION
casual-jca version 2.2.22 provides the ability to add connection listeners.
casual-caller should, whenever a connection is disabled, view this as part of being invalid.
Upon enabling, it will once again, possible ( depending on actual network status), be valid again and thus connected to another casual instance but at the same host:port.