### PR TITLE
handle domain disconnect exeception

### DIFF
--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoriesByPriority.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoriesByPriority.java
@@ -23,7 +23,6 @@ public class ConnectionFactoriesByPriority
 {
     private final Map<Long, List<ConnectionFactoryEntry>> mapping = new ConcurrentHashMap<>();
     private final Set<String> checkedConnectionFactories = new HashSet<>();
-    private final Set<String> foundConnectionFactories = new HashSet<>();
 
     private ConnectionFactoriesByPriority()
     {
@@ -64,7 +63,6 @@ public class ConnectionFactoriesByPriority
         if (!serviceDetails.isEmpty())
         {
             checkedConnectionFactories.add(entry.getJndiName());
-            foundConnectionFactories.add(entry.getJndiName());
             serviceDetails
                     .forEach(discoveryDetails ->
                     {
@@ -91,7 +89,6 @@ public class ConnectionFactoriesByPriority
         // Add missing connection factories for this service and priority
         for (ConnectionFactoryEntry entry : entries)
         {
-            foundConnectionFactories.add(entry.getJndiName());
             if (!listForPriority.contains(entry))
             {
                 listForPriority.add(entry);
@@ -183,7 +180,6 @@ public class ConnectionFactoriesByPriority
 
     public void remove(ConnectionFactoryEntry connectionFactoryEntry)
     {
-        foundConnectionFactories.remove(connectionFactoryEntry.getJndiName());
         checkedConnectionFactories.remove(connectionFactoryEntry.getJndiName());
         for(Map.Entry<Long, List<ConnectionFactoryEntry>> entry : mapping.entrySet())
         {

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/FailoverAlgorithm.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/FailoverAlgorithm.java
@@ -11,6 +11,7 @@ import se.laz.casual.api.buffer.ServiceReturn;
 import se.laz.casual.api.flags.ErrorState;
 import se.laz.casual.jca.CasualConnection;
 import se.laz.casual.network.connection.CasualConnectionException;
+import se.laz.casual.network.connection.DomainDisconnectedException;
 
 import javax.resource.ResourceException;
 import java.util.List;
@@ -120,9 +121,10 @@ public class FailoverAlgorithm
                 // These exceptions are rollback-only, do not attempt any retries.
                 throw new CasualResourceException("Call failed during execution to service=" + serviceName + " on connection=" + connectionFactoryEntry.getJndiName() + " because of a network connection error, retries not possible.", e);
             }
-            catch (ResourceException e)
+            catch (ResourceException | DomainDisconnectedException e)
             {
                 // This error branch will most likely happen on failure to establish connection with a casual backend
+                // or when a casual domain is disconnecting
                 connectionFactoryEntry.invalidate();
 
                 // Do retries on ResourceExceptions. Save the thrown exception and return to the loop

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,9 +7,9 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '2.2.9'
+version = '2.2.10'
 
-def casual_jca_version = '2.2.20'
+def casual_jca_version = '2.2.22'
 def gson_version = '2.10.1'
 
 ext.libs = [


### PR DESCRIPTION
This feature goes along with version 2.2.22 of casual-jca.
A connection can throw DomainDisconnectedException and we handle it exactly the same way as we currently handle ResourceExceptions during tp(a)call.