### PR TITLE
feature/3.2/handle domain disconnect exception

### DIFF
--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoriesByPriority.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoriesByPriority.java
@@ -23,7 +23,6 @@ public class ConnectionFactoriesByPriority
 {
     private final Map<Long, List<ConnectionFactoryEntry>> mapping = new ConcurrentHashMap<>();
     private final Set<String> checkedConnectionFactories = new HashSet<>();
-    private final Set<String> foundConnectionFactories = new HashSet<>();
 
     private ConnectionFactoriesByPriority()
     {
@@ -64,7 +63,6 @@ public class ConnectionFactoriesByPriority
         if (!serviceDetails.isEmpty())
         {
             checkedConnectionFactories.add(entry.getJndiName());
-            foundConnectionFactories.add(entry.getJndiName());
             serviceDetails
                     .forEach(discoveryDetails ->
                     {
@@ -91,7 +89,6 @@ public class ConnectionFactoriesByPriority
         // Add missing connection factories for this service and priority
         for (ConnectionFactoryEntry entry : entries)
         {
-            foundConnectionFactories.add(entry.getJndiName());
             if (!listForPriority.contains(entry))
             {
                 listForPriority.add(entry);
@@ -183,7 +180,6 @@ public class ConnectionFactoriesByPriority
 
     public void remove(ConnectionFactoryEntry connectionFactoryEntry)
     {
-        foundConnectionFactories.remove(connectionFactoryEntry.getJndiName());
         checkedConnectionFactories.remove(connectionFactoryEntry.getJndiName());
         for(Map.Entry<Long, List<ConnectionFactoryEntry>> entry : mapping.entrySet())
         {

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/FailoverAlgorithm.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/FailoverAlgorithm.java
@@ -11,6 +11,7 @@ import se.laz.casual.api.buffer.ServiceReturn;
 import se.laz.casual.api.flags.ErrorState;
 import se.laz.casual.jca.CasualConnection;
 import se.laz.casual.network.connection.CasualConnectionException;
+import se.laz.casual.network.connection.DomainDisconnectedException;
 
 import jakarta.resource.ResourceException;
 import java.util.List;
@@ -120,9 +121,10 @@ public class FailoverAlgorithm
                 // These exceptions are rollback-only, do not attempt any retries.
                 throw new CasualResourceException("Call failed during execution to service=" + serviceName + " on connection=" + connectionFactoryEntry.getJndiName() + " because of a network connection error, retries not possible.", e);
             }
-            catch (ResourceException e)
+            catch (ResourceException | DomainDisconnectedException e)
             {
                 // This error branch will most likely happen on failure to establish connection with a casual backend
+                // or when a casual domain is disconnecting
                 connectionFactoryEntry.invalidate();
 
                 // Do retries on ResourceExceptions. Save the thrown exception and return to the loop

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/TpCallerFailoverTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/TpCallerFailoverTest.groovy
@@ -117,7 +117,7 @@ class TpCallerFailoverTest extends Specification
 
         where:
         _ || exception
-        _ || {msg -> throw new javax.resource.ResourceException('Connection is fail') }
+        _ || {msg -> throw new jakarta.resource.ResourceException('Connection is fail') }
         _ || {msg -> throw new DomainDisconnectedException('Connection is fail') }
     }
 

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/TpCallerFailoverTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/TpCallerFailoverTest.groovy
@@ -13,6 +13,7 @@ import se.laz.casual.api.flags.ErrorState
 import se.laz.casual.api.flags.Flag
 import se.laz.casual.jca.CasualConnection
 import se.laz.casual.jca.CasualConnectionFactory
+import se.laz.casual.network.connection.DomainDisconnectedException
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -103,18 +104,21 @@ class TpCallerFailoverTest extends Specification
                 (priorityHigh): [ConnectionFactoryEntry.of(connectionFactoryProducerHigh)],
                 (priorityLow): [ConnectionFactoryEntry.of(connectionFactoryProducerLow)]
         ])
-        def failMessage = 'Connection is fail'
-
         def someServiceReturn = new ServiceReturn(null, null, null, 0)
 
         when:
         def result = tpCaller.tpcall(serviceName, data, flags, lookupService)
 
         then:
-        1 * conFacHigh.getConnection() >> {throw new ResourceException(failMessage)}
+        1 * conFacHigh.getConnection() >> {exception()}
         0 * conHigh.tpcall(serviceName, data, flags) >> {throw new RuntimeException("This should not happen because getConnection should fail")}
         1 * conLow.tpcall(serviceName, data, flags) >> someServiceReturn
         result == someServiceReturn
+
+        where:
+        _ || exception
+        _ || {msg -> throw new javax.resource.ResourceException('Connection is fail') }
+        _ || {msg -> throw new DomainDisconnectedException('Connection is fail') }
     }
 
     def "2 connection factories with same priority - both are called and fail, exception is thrown"()

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,9 +7,9 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '3.2.9'
+version = '3.2.10'
 
-def casual_jca_version = '3.2.22'
+def casual_jca_version = '3.2.24'
 def gson_version = '2.10.1'
 
 ext.libs = [


### PR DESCRIPTION
This feature goes along with version 3.2.24 of casual-jca.

* A connection can throw DomainDisconnectedException and we handle it exactly the same way as we currently handle ResourceExceptions during tp(a)call.

* Removed data structure not really used, spoke to Tobias and he thinks it is a remnant of something