### PR TITLE
bug, transaction sticky not removed on rollback

### DIFF
--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/FailoverAlgorithm.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/FailoverAlgorithm.java
@@ -186,7 +186,7 @@ public class FailoverAlgorithm
         }
         else if (stickyFactoryMaybe.isPresent())
         {
-            TransactionPoolMapper.getInstance().purgeMappingsForSpecificPool(transactionPoolName);
+            TransactionPoolMapper.getInstance().purgeMappings(transactionPoolName);
         }
 
         LOG.finest(() -> "Failed to call service=" + serviceName + " on stickied pool=" + transactionPoolName + ", falling through to normal flow.");

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/jmx/CasualCallerControl.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/jmx/CasualCallerControl.java
@@ -10,6 +10,7 @@ import se.laz.casual.api.queue.QueueInfo;
 import se.laz.casual.connection.caller.Cache;
 import se.laz.casual.connection.caller.ConnectionFactoryEntry;
 import se.laz.casual.connection.caller.ConnectionFactoryEntryStore;
+import se.laz.casual.connection.caller.TransactionPoolMapper;
 import se.laz.casual.connection.caller.config.ConfigurationService;
 
 import java.util.ArrayList;
@@ -115,5 +116,25 @@ public class CasualCallerControl implements CasualCallerControlMBean
     public boolean transactionStickyEnabled()
     {
         return ConfigurationService.getInstance().getConfiguration().isTransactionStickyEnabled();
+    }
+
+    @Override
+    public void purgeTransactionStickies() {
+        TransactionPoolMapper.getInstance().purgeMappings();
+    }
+
+    @Override
+    public void purgeTransactionStickiesForPool(String poolName) {
+        TransactionPoolMapper.getInstance().purgeMappings(poolName);
+    }
+
+    @Override
+    public Integer currentTransactionStickies() {
+        return TransactionPoolMapper.getInstance().getNumberOfTrackedTransactions();
+    }
+
+    @Override
+    public Integer currentTransactionStickiesForPool(String poolName) {
+        return TransactionPoolMapper.getInstance().getNumberOfTrackedTransactions(poolName);
     }
 }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/jmx/CasualCallerControlMBean.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/jmx/CasualCallerControlMBean.java
@@ -24,4 +24,8 @@ public interface CasualCallerControlMBean
     String getQueueStickiedPool(String queueName);
 
     boolean transactionStickyEnabled();
+    void purgeTransactionStickies();
+    void purgeTransactionStickiesForPool(String poolName);
+    Integer currentTransactionStickies();
+    Integer currentTransactionStickiesForPool(String poolName);
 }

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '3.2.10'
+version = '3.2.11'
 
 def casual_jca_version = '3.2.24'
 def gson_version = '2.10.1'


### PR DESCRIPTION
Transaction stickies in TransactionPoolMapper incorrectly used beforeCompletion in a synchronization to remove stickied transactions. beforeCompletion does not fire for all transactions. Fixed by moving sticky removal to afterCompletion which should fire in all cases like rollbacks etc. where no 2pc takes place.