### PR TITLE
Feature/2.2/list stream nullptr in predicate

### DIFF
--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoriesByPriority.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoriesByPriority.java
@@ -36,14 +36,14 @@ import java.util.stream.Collectors;
     public List<ConnectionFactoryEntry> getForPriority(Long priority)
     {
         // note:
-        // this may return a list with a null value
-        // we handle it at call site
         // due to threading
         // thread 1 calls getOrderedKeys to get the priorities
         // thread 2 gets to run and removes the entries
         // thread 1 continues and calls this method using the now invalid indexes
         // -> nullptr when using the value via for instance a predicate
-        return new ArrayList<>(mapping.get(priority));
+        // thus returning empty list in case of none existence
+        List<ConnectionFactoryEntry> entries = mapping.get(priority);
+        return null == entries ? Collections.emptyList() : new ArrayList<>(entries);
     }
 
     public boolean isEmpty()

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoriesByPriority.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoriesByPriority.java
@@ -34,6 +34,7 @@ public class ConnectionFactoriesByPriority
 
     public List<ConnectionFactoryEntry> getForPriority(Long priority)
     {
+        Objects.requireNonNull(priority, "priority can not be null");
         return prioritizedEntries.get(priority);
     }
 
@@ -44,6 +45,7 @@ public class ConnectionFactoriesByPriority
 
     public void addResolvedFactories(Collection<String> resolvedNames)
     {
+        Objects.requireNonNull(resolvedNames, "resolvedNames can not be null");
         checkedConnectionFactories.addAll(resolvedNames);
     }
 
@@ -59,6 +61,8 @@ public class ConnectionFactoriesByPriority
 
     public void store(List<ServiceDetails> serviceDetails, ConnectionFactoryEntry entry)
     {
+        Objects.requireNonNull(serviceDetails, "serviceDetails can not be null");
+        Objects.requireNonNull(entry, "ConnectionFactoryEntry can not be null");
         if (!serviceDetails.isEmpty())
         {
             checkedConnectionFactories.add(entry.getJndiName());
@@ -72,21 +76,26 @@ public class ConnectionFactoriesByPriority
     }
     public void store(Long priority, List<ConnectionFactoryEntry> entries)
     {
+        Objects.requireNonNull(priority, "priority can not be null");
+        Objects.requireNonNull(entries, "entries can not be null");
         prioritizedEntries.add(priority, entries);
     }
 
     public boolean isResolved(String entryName)
     {
+        Objects.requireNonNull(entryName, "entryName can not be null");
         return checkedConnectionFactories.contains(entryName);
     }
 
     public void setResolved(String entryName)
     {
+        Objects.requireNonNull(entryName, "entryName can not be null");
         checkedConnectionFactories.add(entryName);
     }
 
     public boolean hasCheckedAllValid(List<ConnectionFactoryEntry> entries)
     {
+        Objects.requireNonNull(entries, "entries can not be null");
         for (ConnectionFactoryEntry entry : entries)
         {
             if (!checkedConnectionFactories.contains(entry.getJndiName()) && entry.isValid())
@@ -162,6 +171,7 @@ public class ConnectionFactoriesByPriority
 
     public void remove(ConnectionFactoryEntry connectionFactoryEntry)
     {
+        Objects.requireNonNull(connectionFactoryEntry, "connectionFactoryEntry can not be null");
         checkedConnectionFactories.remove(connectionFactoryEntry.getJndiName());
         prioritizedEntries.remove(connectionFactoryEntry);
     }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryEntry.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryEntry.java
@@ -91,13 +91,13 @@ public class ConnectionFactoryEntry
             return false;
         }
         ConnectionFactoryEntry that = (ConnectionFactoryEntry) o;
-        return isValid() == that.isValid() && connectionFactoryProducer.equals(that.connectionFactoryProducer);
+        return connectionFactoryProducer.equals(that.connectionFactoryProducer);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(connectionFactoryProducer, isValid());
+        return Objects.hash(connectionFactoryProducer);
     }
 
     @Override

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/PrioritizedCollection.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/PrioritizedCollection.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -24,6 +25,7 @@ public class PrioritizedCollection<T>
 
     public List<T> get(Long priority)
     {
+        Objects.requireNonNull(priority, "priority can not be null");
         // note:
         // due to threading
         // thread 1 calls getPriorities to get the priorities
@@ -42,6 +44,8 @@ public class PrioritizedCollection<T>
 
     public PrioritizedCollection<T> add(Long priority, T entry)
     {
+        Objects.requireNonNull(priority, "priority can not be null");
+        Objects.requireNonNull(entry, "entry can not be null");
         Set<T> factoriesForPriority =
                 collection.computeIfAbsent(priority, mapPriority -> ConcurrentHashMap.newKeySet());
         factoriesForPriority.add(entry);
@@ -50,6 +54,8 @@ public class PrioritizedCollection<T>
 
     public PrioritizedCollection<T> add(Long priority, List<T> entries)
     {
+        Objects.requireNonNull(priority, "priority can not be null");
+        Objects.requireNonNull(entries, "entries can not be null");
         Set<T> factoriesForPriority =
                 collection.computeIfAbsent(priority, mapPriority -> ConcurrentHashMap.newKeySet());
         entries.forEach(entry -> {
@@ -67,6 +73,7 @@ public class PrioritizedCollection<T>
 
     public PrioritizedCollection<T> remove(T entryToRemove)
     {
+        Objects.requireNonNull(entryToRemove, "entryToRemove can not be null");
         for (Map.Entry<Long, Set<T>> entry : collection.entrySet())
         {
             entry.getValue().removeIf(cachedEntry -> cachedEntry.equals(entryToRemove));

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/PrioritizedCollection.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/PrioritizedCollection.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2023, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+package se.laz.casual.connection.caller;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+public class PrioritizedCollection<T>
+{
+    private final Map<Long, Set<T>> collection = new ConcurrentHashMap<>();
+
+    public List<Long> getPriorities()
+    {
+        return collection.keySet().stream().sorted().collect(Collectors.toList());
+    }
+
+    public List<T> get(Long priority)
+    {
+        // note:
+        // due to threading
+        // thread 1 calls getPriorities to get the priorities
+        // thread 2 gets to run and removes the entries
+        // thread 1 continues and calls this method using the now invalid indexes
+        // -> nullptr when using the value via for instance a predicate
+        // thus returning empty list in case of none existence
+        Set<T> entries = collection.get(priority);
+        return null == entries ? Collections.emptyList() : new ArrayList<>(entries);
+    }
+
+    public boolean isEmpty()
+    {
+        return collection.isEmpty();
+    }
+
+    public PrioritizedCollection<T> add(Long priority, T entry)
+    {
+        Set<T> factoriesForPriority =
+                collection.computeIfAbsent(priority, mapPriority -> ConcurrentHashMap.newKeySet());
+        factoriesForPriority.add(entry);
+        return this;
+    }
+
+    public PrioritizedCollection<T> add(Long priority, List<T> entries)
+    {
+        Set<T> factoriesForPriority =
+                collection.computeIfAbsent(priority, mapPriority -> ConcurrentHashMap.newKeySet());
+        entries.forEach(entry -> {
+            if (null != entry)
+            {
+                factoriesForPriority.add(entry);
+            }
+        });
+        if(factoriesForPriority.isEmpty())
+        {
+            collection.remove(priority);
+        }
+        return this;
+    }
+
+    public PrioritizedCollection<T> remove(T entryToRemove)
+    {
+        for (Map.Entry<Long, Set<T>> entry : collection.entrySet())
+        {
+            entry.getValue().removeIf(cachedEntry -> cachedEntry.equals(entryToRemove));
+            if (entry.getValue().isEmpty())
+            {
+                collection.remove(entry.getKey());
+            }
+        }
+        return this;
+    }
+
+}

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/ConnectionFactoriesByPriorityTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/ConnectionFactoriesByPriorityTest.groovy
@@ -1,0 +1,52 @@
+package se.laz.casual.connection.caller
+
+import spock.lang.Specification
+
+class ConnectionFactoriesByPriorityTest extends Specification
+{
+   def 'nullptr possible'()
+   {
+      given:
+      def priority = 1L
+      def jndiName = 'jndiFoo'
+      def entryOne = Mock(ConnectionFactoryEntry){
+         getJndiName() >>{
+            jndiName
+         }
+      }
+      def entryTwo = Mock(ConnectionFactoryEntry){
+         getJndiName() >>{
+            jndiName
+         }
+      }
+      def entries = [entryOne, entryTwo]
+      ConnectionFactoriesByPriority instance = ConnectionFactoriesByPriority.of([1L : entries])
+      when:
+      def storedEntries = instance.getForPriority(priority)
+      then:
+      storedEntries == entries
+      when:
+      // note, imagine this being run in two different threads - then this may happen
+      // thread 1
+      def priorities = instance.getOrderedKeys()
+      // thread 2
+      instance.remove(entryOne)
+      instance.remove(entryTwo)
+      // back in  thread 1
+      priorities.each {storedEntries = instance.getForPriority(it)}
+      then:
+      thrown(NullPointerException)
+   }
+
+   def 'do not store null values'()
+   {
+      setup:
+      def priority = 1L
+      ConnectionFactoriesByPriority instance = new ConnectionFactoriesByPriority()
+      when:
+      instance.store(priority, [null])
+      then:
+      instance.isEmpty()
+   }
+
+}

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/ConnectionFactoriesByPriorityTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/ConnectionFactoriesByPriorityTest.groovy
@@ -35,7 +35,7 @@ class ConnectionFactoriesByPriorityTest extends Specification
       // back in  thread 1
       priorities.each {storedEntries = instance.getForPriority(it)}
       then:
-      thrown(NullPointerException)
+      storedEntries.isEmpty()
    }
 
    def 'do not store null values'()

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/PrioritizedCollectionTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/PrioritizedCollectionTest.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+package se.laz.casual.connection.caller
+
+import spock.lang.Specification
+
+class PrioritizedCollectionTest extends Specification
+{
+   def 'testing test'()
+   {
+      given:
+      PrioritizedCollection<String> prioritizedCollection = new PrioritizedCollection<>()
+      def valueOne = 'a'
+      def valueTwo = 'b'
+      def valueThree = 'c'
+      def priorityOne = 0L
+      def priorityTwo = 1L
+      def priorityThree = 2L
+      when:
+      prioritizedCollection.add(priorityOne, [valueOne, valueThree])
+      prioritizedCollection.add(priorityTwo, [valueTwo, valueOne])
+      def atPriorityOne = prioritizedCollection.get(priorityOne)
+      def atPriorityTwo = prioritizedCollection.get(priorityTwo)
+      def atPriorityThree = prioritizedCollection.get(priorityThree)
+      then:
+      atPriorityOne.sort() == [valueOne, valueThree].sort()
+      atPriorityTwo.sort() == [valueTwo, valueOne].sort()
+      atPriorityThree.isEmpty()
+   }
+}

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '2.2.11'
+version = '2.2.12'
 
 def casual_jca_version = '2.2.22'
 def gson_version = '2.10.1'


### PR DESCRIPTION
This should resolve the following issue in FailoverAlgorithm:
`java
private List<ConnectionFactoryEntry> getFoundAndValidEntries(ConnectionFactoryLookup lookup, String serviceName)
    {
        // This is always through the cache, either it was already there or a lookup was issued and then stored
        List<ConnectionFactoryEntry> prioritySortedFactories = lookup.get(serviceName);
        List<ConnectionFactoryEntry> validEntries = prioritySortedFactories.stream().filter(ConnectionFactoryEntry::isValid).collect(Collectors.toList());
        LOG.finest(() -> "Entries found for '" + serviceName + "' with " + validEntries.size() + " of " + prioritySortedFactories.size() + " possible connection factories");
        return validEntries;
    }
`
    The list being returned contains a null element, thus it then explodes with a nullptr exception when the predicate is being evaluated.
    The only way I can see this happening is when we have multiple threads involved.
    * The first one gets the priorities ( ConnectionFactoriesByPriority::getOrderedKeys) 
    * Another thread calls remove - there are no such priorities anymore
    * Thread one gets to run and calls ConnectionFactoriesByPriority::getForPriority - this will now then return a List with a null element
    * FailoverAlgorithm gets the list with the null element and thus we get the nullptr exception.
    
    Please check if you can see any other way that this list can contain a null element in this situation!!!
    
    We've seen this issue in the wild and the only way to reproduce it is with a null element in that list.
    The attribute itself is a boolean so it can not be null.