### PR TITLE
Feature/2.2/timer service non overlapping

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 }
 
 plugins {
-    id 'org.sonarqube' version '2.7'
+  id("org.sonarqube") version "4.4.1.3373"
 }
 
 apply from: 'testsourcesets.gradle'
@@ -23,7 +23,7 @@ defaultTasks 'build'
 sonarqube {
     properties {
         properties["sonar.host.url"] = 'http://localhost:9000'
-        properties["sonar.verbose"] = "true"
+        properties["sonar.verbose"] = 'true'
         properties['sonar.java.source'] = 8
     }
 }
@@ -42,6 +42,29 @@ allprojects{
 subprojects{
   apply from: "$rootProject.projectDir/versions.gradle"
   apply plugin: 'java-library'
+  sonar {
+  properties {
+    properties["sonar.host.url"] = 'http://localhost:9000'
+      properties["sonar.verbose"] = "true"
+      properties['sonar.java.source'] = 8
+    }
+  }
+  apply plugin: 'jacoco'
+  test {
+    finalizedBy jacocoTestReport
+    useJUnitPlatform()
+      testLogging {
+        events "passed", "skipped", "failed"
+      }
+    }
+
+  jacocoTestReport {
+    reports {
+      xml.required = true
+      csv.required = false
+    }
+  }  
+    
 }
 
 project.ext {

--- a/build.gradle
+++ b/build.gradle
@@ -20,14 +20,6 @@ apply from: 'testsourcesets.gradle'
 
 defaultTasks 'build'
 
-sonarqube {
-    properties {
-        properties["sonar.host.url"] = 'http://localhost:9000'
-        properties["sonar.verbose"] = 'true'
-        properties['sonar.java.source'] = 8
-    }
-}
-
 allprojects{
   tasks.withType(JavaCompile) { 
     sourceCompatibility = "8"

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 }
 
 plugins {
-  id("org.sonarqube") version "4.4.1.3373"
+  id("org.sonarqube") version '4.0.0.2929'
 }
 
 apply from: 'testsourcesets.gradle'

--- a/casual/casual-caller/build.gradle
+++ b/casual/casual-caller/build.gradle
@@ -23,7 +23,9 @@ dependencies {
   testImplementation libs.javaee_api
   testImplementation libs.system_lambda
   // for spock
-  testImplementation libs.groovy_all
+  testImplementation platform(libs.groovy_bom)
+  testImplementation libs.groovy
+  testImplementation platform(libs.spock_bom)
   testImplementation libs.spock_core
   testImplementation libs.cglib_nodep
   testImplementation libs.objenesis

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,9 +7,9 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '2.2.17'
+version = '2.2.18'
 
-def casual_jca_version = '2.2.25'
+def casual_jca_version = '2.2.28'
 def gson_version = '2.10.1'
 
 ext.libs = [

--- a/versions.gradle
+++ b/versions.gradle
@@ -24,7 +24,10 @@ ext.libs = [
   commons_io: 'commons-io:commons-io:2.11.0',
   system_lambda: 'com.github.stefanbirkner:system-lambda:1.2.0',
   // for spock
-  groovy_all: 'org.codehaus.groovy:groovy-all:2.5+',
-  spock_core: 'org.spockframework:spock-core:1.3-groovy-2.5',
-  cglib_nodep: 'cglib:cglib-nodep:3.2.4',
+  groovy_bom: 'org.apache.groovy:groovy-bom:4.0.5',
+  groovy: 'org.apache.groovy:groovy',
+  spock_bom: 'org.spockframework:spock-bom:2.3-groovy-4.0',
+  spock_core: 'org.spockframework:spock-core',
+  spock_junit4: 'org.spockframework:spock-junit4',
+  cglib_nodep: 'cglib:cglib-nodep:3.3.0',
 ]


### PR DESCRIPTION
* in case discovery takes longer time than the timeout duration, the timer task should not overlap
* sonar bump
* make sure that unit tests are always run and that code coverage is also measured