### PR TITLE
Bugfix/2.2/handle topology update

### DIFF
--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryEntryStore.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryEntryStore.java
@@ -7,6 +7,7 @@
 package se.laz.casual.connection.caller;
 
 import se.laz.casual.connection.caller.config.ConfigurationService;
+import se.laz.casual.connection.caller.topologychanged.TopologyChangedHandler;
 import se.laz.casual.connection.caller.util.ConnectionFactoryFinder;
 import se.laz.casual.jca.ConnectionObserver;
 import se.laz.casual.jca.DomainId;

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/topologychanged/ScheduleFunction.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/topologychanged/ScheduleFunction.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+package se.laz.casual.connection.caller.topologychanged;
+
+import se.laz.casual.jca.DomainId;
+
+@FunctionalInterface
+public interface ScheduleFunction
+{
+    void scheduleDiscovery(DomainId domainId);
+}

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/topologychanged/TopologyChangedDoneData.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/topologychanged/TopologyChangedDoneData.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+package se.laz.casual.connection.caller.topologychanged;
+
+import se.laz.casual.jca.DomainId;
+
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+public class TopologyChangedDoneData
+{
+    private final Predicate<DomainId> wasUpdatedDuringDiscovery;
+    private final Consumer<DomainId> topologyChangeHandledConsumer;
+    private final Consumer<DomainId> updatedDuringDiscoveryConsumer;
+    private final ScheduleFunction scheduleFunction;
+
+    public static Builder createBuilder()
+    {
+        return new Builder();
+    }
+
+    private TopologyChangedDoneData(Builder builder)
+    {
+        wasUpdatedDuringDiscovery = builder.wasUpdatedDuringDiscovery;
+        topologyChangeHandledConsumer = builder.topologyChangeHandledConsumer;
+        updatedDuringDiscoveryConsumer = builder.updatedDuringDiscoveryConsumer;
+        scheduleFunction = builder.scheduleFunction;
+    }
+
+    public Predicate<DomainId> getWasUpdatedDuringDiscovery()
+    {
+        return wasUpdatedDuringDiscovery;
+    }
+
+    public Consumer<DomainId> getTopologyChangeHandledConsumer()
+    {
+        return topologyChangeHandledConsumer;
+    }
+
+    public Consumer<DomainId> getUpdatedDuringDiscoveryConsumer()
+    {
+        return updatedDuringDiscoveryConsumer;
+    }
+
+    public ScheduleFunction getScheduleFunction()
+    {
+        return scheduleFunction;
+    }
+
+    public static final class Builder
+    {
+        private Predicate<DomainId> wasUpdatedDuringDiscovery;
+        private Consumer<DomainId> topologyChangeHandledConsumer;
+        private Consumer<DomainId> updatedDuringDiscoveryConsumer;
+        private ScheduleFunction scheduleFunction;
+
+        private Builder()
+        {
+        }
+
+        public static Builder newBuilder()
+        {
+            return new Builder();
+        }
+
+        public Builder withWasUpdatedDuringDiscovery(Predicate<DomainId> wasUpdatedDuringDiscovery)
+        {
+            this.wasUpdatedDuringDiscovery = wasUpdatedDuringDiscovery;
+            return this;
+        }
+
+        public Builder withTopologyChangeHandledConsumer(Consumer<DomainId> topologyChangeHandledConsumer)
+        {
+            this.topologyChangeHandledConsumer = topologyChangeHandledConsumer;
+            return this;
+        }
+
+        public Builder withUpdatedDuringDiscoveryConsumer(Consumer<DomainId> updatedDuringDiscoveryConsumer)
+        {
+            this.updatedDuringDiscoveryConsumer = updatedDuringDiscoveryConsumer;
+            return this;
+        }
+
+        public Builder withScheduleFunction(ScheduleFunction scheduleFunction)
+        {
+            this.scheduleFunction = scheduleFunction;
+            return this;
+        }
+
+        public TopologyChangedDoneData build()
+        {
+            return new TopologyChangedDoneData(this);
+        }
+    }
+}

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/topologychanged/TopologyChangedDoneHandler.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/topologychanged/TopologyChangedDoneHandler.java
@@ -7,12 +7,16 @@ package se.laz.casual.connection.caller.topologychanged;
 
 import se.laz.casual.jca.DomainId;
 
+import java.util.Objects;
+
 public final class TopologyChangedDoneHandler
 {
     private TopologyChangedDoneHandler()
     {}
     public static void execute(TopologyChangedDoneData changedData, DomainId domainId)
     {
+        Objects.requireNonNull(changedData, "changedData can not be null");
+        Objects.requireNonNull(domainId, "domainId can not be null");
         if(changedData.getWasUpdatedDuringDiscovery().test(domainId))
         {
             // at least one, topology update while domain discovery was running thus we schedule another domain discovery

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/topologychanged/TopologyChangedDoneHandler.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/topologychanged/TopologyChangedDoneHandler.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+package se.laz.casual.connection.caller.topologychanged;
+
+import se.laz.casual.jca.DomainId;
+
+public final class TopologyChangedDoneHandler
+{
+    private TopologyChangedDoneHandler()
+    {}
+    public static void execute(TopologyChangedDoneData changedData, DomainId domainId)
+    {
+        if(changedData.getWasUpdatedDuringDiscovery().test(domainId))
+        {
+            // at least one, topology update while domain discovery was running thus we schedule another domain discovery
+            changedData.getUpdatedDuringDiscoveryConsumer().accept(domainId);
+            changedData.getScheduleFunction().scheduleDiscovery(domainId);
+        }
+        else
+        {
+            // got no topology updates while discovery was running, we are done
+            changedData.getTopologyChangeHandledConsumer().accept(domainId);
+        }
+    }
+}

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/topologychanged/TopologyChangedHandler.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/topologychanged/TopologyChangedHandler.java
@@ -70,6 +70,7 @@ public class TopologyChangedHandler
     private void scheduleDiscovery(DomainId domainId)
     {
         long delayInMs = ConfigurationService.getInstance().getConfiguration().getTopologyChangeDelayMillis();
+        LOG.finest(() -> "scheduling domain discovery for domain: " + domainId);
         try
         {
             DiscoveryTask task = new DiscoveryTask(domainId, connectionFactoryEntrySupplier, cacheRepopulator);
@@ -121,7 +122,9 @@ public class TopologyChangedHandler
             Optional<ConnectionFactoryEntry> maybeMatch = connectionFactoryEntrySupplier.get().stream()
                                                                                         .filter(connectionFactoryEntry -> DomainIdChecker.isSameDomain(domainId, connectionFactoryEntry))
                                                                                         .findFirst();
+            LOG.finest(() -> "will issue domain discovery for domain: " + domainId);
             maybeMatch.ifPresent(cacheRepopulator::repopulate);
+            LOG.finest(() -> "domain discovery finished for domain: " + domainId);
             // if no match, then that connection is gone and the cache will be repopulated once it re-establishes a connection
             TopologyChangedDoneHandler.execute(TopologyChangedDoneData.createBuilder()
                                                                       .withWasUpdatedDuringDiscovery(updateRequestDuringDiscovery::contains)

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/ConnectionFactoryProviderTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/ConnectionFactoryProviderTest.groovy
@@ -5,6 +5,7 @@
  */
 package se.laz.casual.connection.caller
 
+import se.laz.casual.connection.caller.topologychanged.TopologyChangedHandler
 import se.laz.casual.connection.caller.util.ConnectionFactoryFinder
 import spock.lang.Specification
 

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/TopologyChangedHandlerTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/TopologyChangedHandlerTest.groovy
@@ -6,6 +6,7 @@
 package se.laz.casual.connection.caller
 
 import se.laz.casual.connection.caller.config.ConfigurationService
+import se.laz.casual.connection.caller.topologychanged.TopologyChangedHandler
 import se.laz.casual.jca.CasualConnection
 import se.laz.casual.jca.CasualConnectionFactory
 import se.laz.casual.jca.DomainId

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/TopologyChangedHandlerTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/TopologyChangedHandlerTest.groovy
@@ -13,7 +13,11 @@ import se.laz.casual.jca.DomainId
 import spock.lang.Specification
 
 import javax.enterprise.concurrent.ManagedScheduledExecutorService
-import java.util.concurrent.*
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
 import java.util.function.Supplier
 
 class TopologyChangedHandlerTest extends Specification

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/topologychanged/TopologyChangedDoneHandlerTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/topologychanged/TopologyChangedDoneHandlerTest.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+package se.laz.casual.connection.caller.topologychanged
+
+import se.laz.casual.jca.DomainId
+import spock.lang.Specification
+
+import java.util.concurrent.ConcurrentHashMap
+
+class TopologyChangedDoneHandlerTest extends Specification
+{
+   Set<DomainId> changedDomains = ConcurrentHashMap.newKeySet();
+   Set<DomainId> updateRequestDuringDiscovery = ConcurrentHashMap.newKeySet();
+   DomainId domainId = DomainId.of(UUID.randomUUID())
+   def setup()
+   {
+      changedDomains.clear()
+      updateRequestDuringDiscovery.clear()
+   }
+   def 'no update during discovery'()
+   {
+      given:
+      changedDomains.add(domainId)
+      when:
+      ScheduleFunction scheduleFunction = Mock(ScheduleFunction){
+         0 * scheduleDiscovery(domainId)
+      }
+      TopologyChangedDoneHandler.execute(TopologyChangedDoneData.createBuilder()
+              .withWasUpdatedDuringDiscovery(updateRequestDuringDiscovery::contains)
+              .withUpdatedDuringDiscoveryConsumer(updateRequestDuringDiscovery::remove)
+              .withTopologyChangeHandledConsumer(changedDomains::remove)
+              .withScheduleFunction(scheduleFunction)
+              .build(), domainId);
+      then:
+      !changedDomains.contains(domainId)
+      !updateRequestDuringDiscovery.contains(domainId)
+   }
+
+   def 'update during discovery'()
+   {
+      given:
+      changedDomains.add(domainId)
+      updateRequestDuringDiscovery.add(domainId)
+      when:
+      ScheduleFunction scheduleFunction = Mock(ScheduleFunction){
+         1 * scheduleDiscovery(domainId)
+      }
+      TopologyChangedDoneHandler.execute(TopologyChangedDoneData.createBuilder()
+              .withWasUpdatedDuringDiscovery(updateRequestDuringDiscovery::contains)
+              .withUpdatedDuringDiscoveryConsumer(updateRequestDuringDiscovery::remove)
+              .withTopologyChangeHandledConsumer(changedDomains::remove)
+              .withScheduleFunction(scheduleFunction)
+              .build(), domainId);
+      then:
+      changedDomains.contains(domainId)
+      !updateRequestDuringDiscovery.contains(domainId)
+   }
+
+}

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,9 +7,9 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '2.2.18'
+version = '2.2.19'
 
-def casual_jca_version = '2.2.28'
+def casual_jca_version = '2.2.32'
 def gson_version = '2.10.1'
 
 ext.libs = [


### PR DESCRIPTION
* Do not schedule any new domain discovery while one is already running
* If we get an incoming topology update while domain discovery is running, make note of it and schedule it after the domain discovery has finished. Also keep the lock for not issuing new domain discoveries while a domain discovery is running.

This is so that we use as little resources as possible when handling topology updates.

Issue #32