### PR TITLE
Feature/3.2/execution sticky

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ This is just a convenience layer for applications to make use, it does not in an
 This, 3.2, branch is for Jakarta EE and Java 17.
 If you want to use Java 8 and Java EE - please check out the 2.2 branch.
 
+## casual jca version dependency
+```casual-caller``` v3.2.20+ needs ```casual-jca``` version 3.2.44+
+
 ## Requirements on setup of connection pools
 
 Connection factories for outbound connection pool(s) has to exist under the same JNDI-root.

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ allprojects{
     options.compilerArgs << "-Xlint:all" << "-Werror"
   }
   repositories {
-        mavenCentral()
+    mavenCentral()
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,8 @@ allprojects{
     options.compilerArgs << "-Xlint:all" << "-Werror"
   }
   repositories {
-    mavenCentral()
+        mavenCentral()
+        maven {url 'https://s01.oss.sonatype.org/content/repositories/snapshots' }
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,6 @@ allprojects{
   }
   repositories {
         mavenCentral()
-        maven {url 'https://s01.oss.sonatype.org/content/repositories/snapshots' }
   }
 }
 

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/CasualCallerImpl.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/CasualCallerImpl.java
@@ -26,6 +26,7 @@ import jakarta.inject.Inject;
 import jakarta.resource.ResourceException;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 @Remote(CasualCaller.class)
@@ -63,10 +64,22 @@ public class CasualCallerImpl implements CasualCaller
     }
 
     @Override
+    public ServiceReturn<CasualBuffer> tpcall(String s, CasualBuffer casualBuffer, Flag<AtmiFlags> flag, UUID execution)
+    {
+        throw new UnsupportedOperationException("Casual caller does not support tpcall with execution");
+    }
+
+    @Override
     public CompletableFuture<Optional<ServiceReturn<CasualBuffer>>> tpacall(String serviceName, CasualBuffer data, Flag<AtmiFlags> flags)
     {
         failedDomainDiscoveryHandler.issueDomainDiscoveryAndRepopulateCache();
         return flags.isSet(AtmiFlags.TPNOTRAN) ? transactionLess.tpacall(() -> tpCaller.tpacall(serviceName, data, flags, lookup)) : tpCaller.tpacall(serviceName, data, flags, lookup);
+    }
+
+    @Override
+    public CompletableFuture<Optional<ServiceReturn<CasualBuffer>>> tpacall(String s, CasualBuffer casualBuffer, Flag<AtmiFlags> flag, UUID uuid)
+    {
+        throw new UnsupportedOperationException("Casual caller does not support tpacall with execution");
     }
 
     @Override

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/FailoverAlgorithm.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/FailoverAlgorithm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2023, The casual project. All rights reserved.
+ * Copyright (c) 2021 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/FailoverAlgorithm.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/FailoverAlgorithm.java
@@ -10,6 +10,8 @@ import jakarta.resource.ResourceException;
 import se.laz.casual.api.buffer.CasualBuffer;
 import se.laz.casual.api.buffer.ServiceReturn;
 import se.laz.casual.api.flags.ErrorState;
+import se.laz.casual.connection.caller.functions.FunctionNoArg;
+import se.laz.casual.connection.caller.functions.FunctionThrowsResourceException;
 import se.laz.casual.jca.CasualConnection;
 import se.laz.casual.network.connection.CasualConnectionException;
 import se.laz.casual.network.connection.DomainDisconnectedException;
@@ -29,7 +31,7 @@ public class FailoverAlgorithm
     public ServiceReturn<CasualBuffer> tpcallWithFailover(
             String serviceName,
             ConnectionFactoryLookup lookup,
-            FunctionThrowsResourceException<CasualConnection, ServiceReturn<CasualBuffer>> doCall,
+            FunctionThrowsResourceException<ServiceReturn<CasualBuffer>> doCall,
             FunctionNoArg<ServiceReturn<CasualBuffer>> doTpenoent)
     {
         List<ConnectionFactoryEntry> validEntries = getFoundAndValidEntries(lookup, serviceName);
@@ -63,7 +65,7 @@ public class FailoverAlgorithm
     public CompletableFuture<Optional<ServiceReturn<CasualBuffer>>> tpacallWithFailover(
             String serviceName,
             ConnectionFactoryLookup lookup,
-            FunctionThrowsResourceException<CasualConnection, CompletableFuture<Optional<ServiceReturn<CasualBuffer>>>> doCall,
+            FunctionThrowsResourceException<CompletableFuture<Optional<ServiceReturn<CasualBuffer>>>> doCall,
             FunctionNoArg<CompletableFuture<Optional<ServiceReturn<CasualBuffer>>>> doTpenoent)
     {
         List<ConnectionFactoryEntry> validEntries = getFoundAndValidEntries(lookup, serviceName);
@@ -86,14 +88,14 @@ public class FailoverAlgorithm
         return validEntries;
     }
 
-    private <T> T issueCall(String serviceName, List<ConnectionFactoryEntry> validEntries, FunctionThrowsResourceException<CasualConnection, T> doCall)
+    private <T> T issueCall(String serviceName, List<ConnectionFactoryEntry> validEntries, FunctionThrowsResourceException<T> doCall)
     {
         Exception thrownException = null;
 
         // Sticky transaction handling
         try
         {
-            Optional<T> stickyMaybe = handleTransactionSticky(serviceName, validEntries, doCall);
+            Optional<T> stickyMaybe = StickyTransactionHandler.handleTransactionSticky(serviceName, validEntries, doCall, TransactionPoolMapper::getInstance);
 
             if (stickyMaybe.isPresent())
             {
@@ -136,100 +138,4 @@ public class FailoverAlgorithm
         throw new CasualResourceException("Call failed to all " + validEntries.size() + " available casual connections.", thrownException);
     }
 
-    /**
-     * Try to use a stickied pool if pool stickiness is configured and any stickied pool is available and serves the requested service
-     *
-     * @param serviceName Service to call
-     * @param factories   Currently available factories for service to call
-     * @param doCall      Provided service call procedure
-     * @return Optional ServiceReturn. An empty result could indicate that stickiness isn't enabled, sticky isn't set yet for the current transaction (which will be the case for the first call) or the stickied pool was unavailable so call to sticky was skipped. Empty should always lead to retry down the line if possible, otherwise a TPENOENT response.
-     * @throws ResourceException Some softer errors are reported as resource exceptions. If these are thrown later retries with other pools is possible.
-     */
-    private <T> Optional<T> handleTransactionSticky(
-            String serviceName,
-            List<ConnectionFactoryEntry> factories,
-            FunctionThrowsResourceException<CasualConnection, T> doCall) throws ResourceException
-    {
-        if (!TransactionPoolMapper.getInstance().isPoolMappingActive())
-        {
-            return Optional.empty();
-        }
-
-        Optional<StickiedCallInfo> stickyMaybe = getAndSetSticky(serviceName, factories);
-
-        if (stickyMaybe.isPresent())
-        {
-            // We have a specific stickied pool to use that looks usable, try to use it
-            StickiedCallInfo sticky = stickyMaybe.get();
-            factories.remove(sticky.connectionFactoryEntry()); // If we later need to do failover stuff we don't want to retry with this one
-            LOG.finest(() -> "Attempting to use pool=" + sticky.connectionFactoryEntry().getJndiName() + " with sticky to current transaction.");
-            try (CasualConnection con = sticky.connectionFactoryEntry().getConnectionFactory().getConnection())
-            {
-                return Optional.of(doCall.apply(con, sticky.execution()));
-            }
-            catch (CasualConnectionException e)
-            {
-                //This error branch will most likely happen if there are connection errors during a service call
-                sticky.connectionFactoryEntry().invalidate();
-
-                // These exceptions are rollback-only, do not attempt any retries.
-                throw new CasualResourceException("Call failed during execution to service=" + serviceName
-                        + " on connection=" + sticky.connectionFactoryEntry().getJndiName()
-                        + " because of a network connection error, retries not possible.", e);
-            }
-        }
-        else
-        {
-            LOG.finest(() -> "Current sticky is " + TransactionPoolMapper.getInstance().getStickyInformationForCurrentTransaction()
-                    + " but called service=" + serviceName
-                    + " is currently available in pools [" + factories.stream().map(ConnectionFactoryEntry::getJndiName).collect(Collectors.joining(","))
-                    + "]. Will use available pools instead of stickied pool.");
-            return Optional.empty();
-        }
-    }
-
-    private Optional<StickiedCallInfo> getAndSetSticky(String serviceName, List<ConnectionFactoryEntry> validFactories)
-    {
-        StickyInformation stickyInformation = TransactionPoolMapper.getInstance().getStickyInformationForCurrentTransaction();
-
-        if (stickyInformation == null)
-        {
-            // Service exists in some pool, pick first one as sticky (would otherwise be picked later in normal flow)
-            ConnectionFactoryEntry newStickyFactory = validFactories.get(0);
-            StickyInformation newStickyInformation = new StickyInformation(newStickyFactory.getJndiName(), UUID.randomUUID());
-            TransactionPoolMapper.getInstance().setStickyInformationForCurrentTransaction(newStickyInformation);
-            LOG.finest(() -> "No sticky present for call to service=" + serviceName + ", setting sticky=" + newStickyFactory.getJndiName() + " with=" + newStickyInformation);
-            return Optional.of(new StickiedCallInfo(newStickyFactory, newStickyInformation.execution()));
-        }
-        else
-        {
-            Optional<ConnectionFactoryEntry> stickyMatch = validFactories
-                    .stream()
-                    .filter(connectionFactoryEntry -> stickyInformation.poolName().equals(connectionFactoryEntry.getJndiName()) && connectionFactoryEntry.isValid())
-                    .findFirst();
-
-            if (stickyMatch.isPresent())
-            {
-                LOG.finest(() -> "Using stickied pool=" + stickyInformation + " for call to service=" + serviceName);
-                ConnectionFactoryEntry stickyEntry = stickyMatch.get();
-                validFactories.remove(stickyEntry);
-                return Optional.of(new StickiedCallInfo(stickyEntry, stickyInformation.execution()));
-            }
-            else
-            {
-                LOG.finest(() -> "There was a sticky=" + stickyInformation + ", but it did not match the valid factories for the called service=" + serviceName);
-                return Optional.empty();
-            }
-        }
-    }
-
-    public interface FunctionNoArg<R>
-    {
-        R apply();
-    }
-
-    public interface FunctionThrowsResourceException<I, R>
-    {
-        R apply(I input, UUID Execution) throws ResourceException;
-    }
 }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/StickiedCallInfo.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/StickiedCallInfo.java
@@ -1,0 +1,13 @@
+package se.laz.casual.connection.caller;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record StickiedCallInfo(ConnectionFactoryEntry connectionFactoryEntry, UUID execution)
+{
+    public StickiedCallInfo
+    {
+        Objects.requireNonNull(connectionFactoryEntry, "connectionFactoryEntry can not be null");
+        Objects.requireNonNull(execution, "execution can not be null");
+    }
+}

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/StickyInformation.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/StickyInformation.java
@@ -1,0 +1,13 @@
+package se.laz.casual.connection.caller;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record StickyInformation(String poolName, UUID execution)
+{
+    public StickyInformation
+    {
+        Objects.requireNonNull(poolName, "poolName can not be null");
+        Objects.requireNonNull(execution, "execution can not be null");
+    }
+}

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/StickyTransactionHandler.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/StickyTransactionHandler.java
@@ -21,6 +21,9 @@ import se.laz.casual.network.connection.CasualConnectionException;
 public class StickyTransactionHandler
 {
     private static final Logger LOG = Logger.getLogger(StickyTransactionHandler.class.getName());
+
+    private StickyTransactionHandler()
+    {}
     /**
      * Try to use a stickied pool if pool stickiness is configured and any stickied pool is available and serves the requested service
      *

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/StickyTransactionHandler.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/StickyTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, The casual project. All rights reserved.
+ * Copyright (c) 2021 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/StickyTransactionHandler.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/StickyTransactionHandler.java
@@ -1,0 +1,106 @@
+package se.laz.casual.connection.caller;
+
+import jakarta.resource.ResourceException;
+import se.laz.casual.jca.CasualConnection;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import se.laz.casual.connection.caller.functions.FunctionThrowsResourceException;
+import se.laz.casual.network.connection.CasualConnectionException;
+
+public class StickyTransactionHandler
+{
+    private static final Logger LOG = Logger.getLogger(StickyTransactionHandler.class.getName());
+    /**
+     * Try to use a stickied pool if pool stickiness is configured and any stickied pool is available and serves the requested service
+     *
+     * @param serviceName Service to call
+     * @param factories   Currently available factories for service to call
+     * @param doCall      Provided service call procedure
+     * @return Optional ServiceReturn. An empty result could indicate that stickiness isn't enabled, sticky isn't set yet for the current transaction (which will be the case for the first call) or the stickied pool was unavailable so call to sticky was skipped. Empty should always lead to retry down the line if possible, otherwise a TPENOENT response.
+     * @throws ResourceException Some softer errors are reported as resource exceptions. If these are thrown later retries with other pools is possible.
+     */
+    public static <T> Optional<T> handleTransactionSticky(
+            String serviceName,
+            List<ConnectionFactoryEntry> factories,
+            FunctionThrowsResourceException<T> doCall,
+            Supplier<TransactionPoolMapper> transactionPoolMapperSupplier) throws ResourceException
+    {
+        if (!transactionPoolMapperSupplier.get().isPoolMappingActive())
+        {
+            return Optional.empty();
+        }
+
+        Optional<StickiedCallInfo> stickyMaybe = getAndSetSticky(serviceName, factories, transactionPoolMapperSupplier);
+
+        if (stickyMaybe.isPresent())
+        {
+            // We have a specific stickied pool to use that looks usable, try to use it
+            StickiedCallInfo sticky = stickyMaybe.get();
+            factories.remove(sticky.connectionFactoryEntry()); // If we later need to do failover stuff we don't want to retry with this one
+            LOG.finest(() -> "Attempting to use pool=" + sticky.connectionFactoryEntry().getJndiName() + " with sticky to current transaction.");
+            try (CasualConnection con = sticky.connectionFactoryEntry().getConnectionFactory().getConnection())
+            {
+                return Optional.of(doCall.apply(con, sticky.execution()));
+            }
+            catch (CasualConnectionException e)
+            {
+                //This error branch will most likely happen if there are connection errors during a service call
+                sticky.connectionFactoryEntry().invalidate();
+
+                // These exceptions are rollback-only, do not attempt any retries.
+                throw new CasualResourceException("Call failed during execution to service=" + serviceName
+                        + " on connection=" + sticky.connectionFactoryEntry().getJndiName()
+                        + " because of a network connection error, retries not possible.", e);
+            }
+        }
+        else
+        {
+            LOG.finest(() -> "Current sticky is " + transactionPoolMapperSupplier.get().getStickyInformationForCurrentTransaction()
+                    + " but called service=" + serviceName
+                    + " is currently available in pools [" + factories.stream().map(ConnectionFactoryEntry::getJndiName).collect(Collectors.joining(","))
+                    + "]. Will use available pools instead of stickied pool.");
+            return Optional.empty();
+        }
+    }
+
+    private static Optional<StickiedCallInfo> getAndSetSticky(String serviceName, List<ConnectionFactoryEntry> validFactories, Supplier<TransactionPoolMapper> transactionPoolMapperSupplier)
+    {
+        StickyInformation stickyInformation = transactionPoolMapperSupplier.get().getStickyInformationForCurrentTransaction();
+
+        if (stickyInformation == null)
+        {
+            // Service exists in some pool, pick first one as sticky (would otherwise be picked later in normal flow)
+            ConnectionFactoryEntry newStickyFactory = validFactories.get(0);
+            StickyInformation newStickyInformation = new StickyInformation(newStickyFactory.getJndiName(), UUID.randomUUID());
+            transactionPoolMapperSupplier.get().setStickyInformationForCurrentTransaction(newStickyInformation);
+            LOG.finest(() -> "No sticky present for call to service=" + serviceName + ", setting sticky=" + newStickyFactory.getJndiName() + " with=" + newStickyInformation);
+            return Optional.of(new StickiedCallInfo(newStickyFactory, newStickyInformation.execution()));
+        }
+        else
+        {
+            Optional<ConnectionFactoryEntry> stickyMatch = validFactories
+                    .stream()
+                    .filter(connectionFactoryEntry -> stickyInformation.poolName().equals(connectionFactoryEntry.getJndiName()) && connectionFactoryEntry.isValid())
+                    .findFirst();
+
+            if (stickyMatch.isPresent())
+            {
+                LOG.finest(() -> "Using stickied pool=" + stickyInformation + " for call to service=" + serviceName);
+                ConnectionFactoryEntry stickyEntry = stickyMatch.get();
+                validFactories.remove(stickyEntry);
+                return Optional.of(new StickiedCallInfo(stickyEntry, stickyInformation.execution()));
+            }
+            else
+            {
+                LOG.finest(() -> "There was a sticky=" + stickyInformation + ", but it did not match the valid factories for the called service=" + serviceName);
+                return Optional.empty();
+            }
+        }
+    }
+}

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/StickyTransactionHandler.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/StickyTransactionHandler.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
 package se.laz.casual.connection.caller;
 
 import jakarta.resource.ResourceException;

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/TpCaller.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/TpCaller.java
@@ -12,7 +12,6 @@ import se.laz.casual.api.flags.AtmiFlags;
 import se.laz.casual.api.flags.Flag;
 
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 public interface TpCaller

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/TpCaller.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/TpCaller.java
@@ -12,11 +12,11 @@ import se.laz.casual.api.flags.AtmiFlags;
 import se.laz.casual.api.flags.Flag;
 
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 public interface TpCaller
 {
     ServiceReturn<CasualBuffer> tpcall(String serviceName, CasualBuffer data, Flag<AtmiFlags> flags, ConnectionFactoryLookup lookup);
-
     CompletableFuture<Optional<ServiceReturn<CasualBuffer>>> tpacall(String serviceName, CasualBuffer data, Flag<AtmiFlags> flags, ConnectionFactoryLookup lookup);
 }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/TpCallerFailover.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/TpCallerFailover.java
@@ -38,7 +38,7 @@ public class TpCallerFailover implements TpCaller
                 serviceName,
                 lookup,
                 // How to call service
-                con -> con.tpcall(serviceName, data, flags),
+                (con, execution) -> con.tpcall(serviceName, data, flags, execution),
                 // What to do if the cache has no entries
                 this::tpenoentReply
         );
@@ -51,7 +51,7 @@ public class TpCallerFailover implements TpCaller
                 serviceName,
                 lookup,
                 // How to call service
-                con -> con.tpacall(serviceName, data, flags),
+                (con, execution) -> con.tpacall(serviceName, data, flags, execution),
                 // What to do if the cache has no entries
                 () -> CompletableFuture.supplyAsync(this::optionalTpenoentReply)
         );

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/TransactionPoolMapper.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/TransactionPoolMapper.java
@@ -177,7 +177,7 @@ public class TransactionPoolMapper
     public int getNumberOfTrackedTransactions(String poolName)
     {
         Objects.requireNonNull(poolName, "poolName must have a value");
-        return (int) transactionStickies.values().stream().filter(s -> s.equals(poolName)).count();
+        return (int) transactionStickies.values().stream().filter(s -> s.poolName().equals(poolName)).count();
     }
 
     /**

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/TransactionPoolMapper.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/TransactionPoolMapper.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-public final class TransactionPoolMapper
+public class TransactionPoolMapper
 {
     private static final Logger LOG = Logger.getLogger(TransactionPoolMapper.class.getName());
     private final Map<Transaction, StickyInformation> transactionStickies = new ConcurrentHashMap<>();

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/functions/FunctionNoArg.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/functions/FunctionNoArg.java
@@ -1,0 +1,7 @@
+package se.laz.casual.connection.caller.functions;
+
+@FunctionalInterface
+public interface FunctionNoArg<R>
+{
+    R apply();
+}

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/functions/FunctionNoArg.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/functions/FunctionNoArg.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2021 - 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
 package se.laz.casual.connection.caller.functions;
 
 @FunctionalInterface

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/functions/FunctionThrowsResourceException.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/functions/FunctionThrowsResourceException.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2021 - 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
 package se.laz.casual.connection.caller.functions;
 
 import jakarta.resource.ResourceException;

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/functions/FunctionThrowsResourceException.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/functions/FunctionThrowsResourceException.java
@@ -1,0 +1,12 @@
+package se.laz.casual.connection.caller.functions;
+
+import jakarta.resource.ResourceException;
+import se.laz.casual.jca.CasualConnection;
+
+import java.util.UUID;
+
+@FunctionalInterface
+public interface FunctionThrowsResourceException <R>
+{
+    R apply(CasualConnection connection, UUID execution) throws ResourceException;
+}

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/CasualCallerImplTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/CasualCallerImplTest.groovy
@@ -221,7 +221,7 @@ class CasualCallerImplTest extends Specification
         def flags = Flag.of(AtmiFlags.NOFLAG)
         connectionFactory.getConnection() >> {
             def connection = Mock(CasualConnection)
-            1 * connection.tpcall(serviceName, callingBuffer, flags) >> serviceReturn
+            1 * connection.tpcall(serviceName, callingBuffer, flags, _ as UUID) >> serviceReturn
             return connection
         }
         def producer = Mock(ConnectionFactoryProducer){
@@ -252,7 +252,7 @@ class CasualCallerImplTest extends Specification
         def flags = Flag.of(AtmiFlags.NOFLAG)
         connectionFactory.getConnection() >> {
             def connection = Mock(CasualConnection)
-            1 * connection.tpacall(serviceName, callingBuffer, flags) >> future
+            1 * connection.tpacall(serviceName, callingBuffer, flags, _ as UUID) >> future
             return connection
         }
         def producer = Mock(ConnectionFactoryProducer){

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/FailoverAlgorithmTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/FailoverAlgorithmTest.groovy
@@ -183,7 +183,7 @@ class FailoverAlgorithmTest extends Specification
       response2.errorState == ErrorState.OK
 
       TransactionPoolMapper.getInstance().getNumberOfTrackedTransactions() == 1
-      TransactionPoolMapper.getInstance().getPoolNameForCurrentTransaction() == pool1name
+      TransactionPoolMapper.getInstance().getStickyInformationForCurrentTransaction() == pool1name
    }
 
    def 'stickies, failover: when calling stickied service failover is possible to other non-stickied pool'()
@@ -215,7 +215,7 @@ class FailoverAlgorithmTest extends Specification
       then:
       response1.errorState == ErrorState.OK
       TransactionPoolMapper.getInstance().getNumberOfTrackedTransactions() == 1
-      TransactionPoolMapper.getInstance().getPoolNameForCurrentTransaction() == pool1name
+      TransactionPoolMapper.getInstance().getStickyInformationForCurrentTransaction() == pool1name
    }
 
    private ConnectionFactoryEntry getFactoryMockServiceReturn(String jndiName, ServiceReturn<CasualBuffer> expectedReturn)

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/FailoverAlgorithmTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/FailoverAlgorithmTest.groovy
@@ -74,7 +74,7 @@ class FailoverAlgorithmTest extends Specification
       ServiceReturn<CasualBuffer> response = failoverAlgorithm.tpcallWithFailover(
               service,
               lookup,
-              {con -> con.tpcall(service, ServiceBuffer.empty(), Flag.of())},
+              {con,execution -> con.tpcall(service, ServiceBuffer.empty(), Flag.of(), execution)},
               {serviceReturnTpenoent})
 
       then:
@@ -104,7 +104,7 @@ class FailoverAlgorithmTest extends Specification
       ServiceReturn<CasualBuffer> response = failoverAlgorithm.tpcallWithFailover(
               service,
               lookup,
-              {con -> con.tpcall(service, ServiceBuffer.empty(), Flag.of())},
+              {con, execution -> con.tpcall(service, ServiceBuffer.empty(), Flag.of(), execution)},
               {serviceReturnTpenoent})
 
       then:
@@ -134,7 +134,7 @@ class FailoverAlgorithmTest extends Specification
       ServiceReturn<CasualBuffer> response = failoverAlgorithm.tpcallWithFailover(
               service,
               lookup,
-              {con -> con.tpcall(service, ServiceBuffer.empty(), Flag.of())},
+              {con, execution -> con.tpcall(service, ServiceBuffer.empty(), Flag.of(), execution)},
               {serviceReturnTpenoent})
 
       then:
@@ -169,13 +169,13 @@ class FailoverAlgorithmTest extends Specification
       ServiceReturn<CasualBuffer> response1 = failoverAlgorithm.tpcallWithFailover(
               service1,
               lookup,
-              {con -> con.tpcall(service1, ServiceBuffer.empty(), Flag.of())},
+              {con, execution -> con.tpcall(service1, ServiceBuffer.empty(), Flag.of(), execution)},
               {serviceReturnTpenoent})
 
       ServiceReturn<CasualBuffer> response2 = failoverAlgorithm.tpcallWithFailover(
               service2,
               lookup,
-              {con -> con.tpcall(service2, ServiceBuffer.empty(), Flag.of())},
+              {con, execution -> con.tpcall(service2, ServiceBuffer.empty(), Flag.of(), execution)},
               {serviceReturnTpenoent})
 
       then:
@@ -183,7 +183,7 @@ class FailoverAlgorithmTest extends Specification
       response2.errorState == ErrorState.OK
 
       TransactionPoolMapper.getInstance().getNumberOfTrackedTransactions() == 1
-      TransactionPoolMapper.getInstance().getStickyInformationForCurrentTransaction() == pool1name
+      TransactionPoolMapper.getInstance().getStickyInformationForCurrentTransaction().poolName() == pool1name
    }
 
    def 'stickies, failover: when calling stickied service failover is possible to other non-stickied pool'()
@@ -209,13 +209,13 @@ class FailoverAlgorithmTest extends Specification
       ServiceReturn<CasualBuffer> response1 = failoverAlgorithm.tpcallWithFailover(
               service1,
               lookup,
-              {con -> con.tpcall(service1, ServiceBuffer.empty(), Flag.of())},
+              {con, execution -> con.tpcall(service1, ServiceBuffer.empty(), Flag.of(), execution)},
               {serviceReturnTpenoent})
 
       then:
       response1.errorState == ErrorState.OK
       TransactionPoolMapper.getInstance().getNumberOfTrackedTransactions() == 1
-      TransactionPoolMapper.getInstance().getStickyInformationForCurrentTransaction() == pool1name
+      TransactionPoolMapper.getInstance().getStickyInformationForCurrentTransaction().poolName() == pool1name
    }
 
    private ConnectionFactoryEntry getFactoryMockServiceReturn(String jndiName, ServiceReturn<CasualBuffer> expectedReturn)

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/StickyTransactionHandlerTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/StickyTransactionHandlerTest.groovy
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+package se.laz.casual.connection.caller
+
+import jakarta.transaction.Status
+import jakarta.transaction.TransactionManager
+import se.laz.casual.api.buffer.CasualBuffer
+import se.laz.casual.api.buffer.ServiceReturn
+import se.laz.casual.api.buffer.type.ServiceBuffer
+import se.laz.casual.api.flags.ErrorState
+import se.laz.casual.api.flags.Flag
+import se.laz.casual.api.flags.ServiceReturnState
+import se.laz.casual.jca.CasualConnection
+import se.laz.casual.jca.CasualConnectionFactory
+import spock.lang.Shared
+import spock.lang.Specification
+
+class StickyTransactionHandlerTest extends Specification
+{
+   @Shared
+   ServiceReturn<CasualBuffer> serviceReturnSuccess = new ServiceReturn<>(ServiceBuffer.empty(), ServiceReturnState.TPSUCCESS, ErrorState.OK, 0L)
+
+   def cleanup()
+   {
+      TransactionPoolMapper.resetForTest()
+   }
+
+   def 'sticky not active'()
+   {
+      given:
+      TransactionPoolMapper mapper = Mock(TransactionPoolMapper){
+         isPoolMappingActive() >> false
+      }
+      when:
+      Optional result = StickyTransactionHandler.handleTransactionSticky('serviceOne', [], {con, execution -> }, () -> mapper)
+      then:
+      result.isEmpty()
+   }
+
+   def '2 calls in the same transaction, sticky - should use the same connection and execution'()
+   {
+      given:
+      enableTransactionStickyForTest()
+      def poolName = "eis/pool-one"
+      def expectedNumberOfCalls = 2
+      def connectionFactory = getFactoryMockServiceReturn(poolName, serviceReturnSuccess, expectedNumberOfCalls)
+      def factories = [connectionFactory]
+      def factoriesSubsequentCall = [connectionFactory]
+      def service1 = "service1"
+      def service2 = "service2"
+      when:
+      Optional<ServiceReturn<CasualBuffer>> response = StickyTransactionHandler.handleTransactionSticky(service1,
+              factories,
+              {con, execution -> con.tpcall(service1, ServiceBuffer.empty(), Flag.of(), execution)},
+              {TransactionPoolMapper.getInstance()})
+      then:
+      response.get().errorState == ErrorState.OK
+      TransactionPoolMapper.getInstance().getNumberOfTrackedTransactions() == 1
+      TransactionPoolMapper.getInstance().getStickyInformationForCurrentTransaction().poolName() == poolName
+      when:
+      UUID sharedExecution = TransactionPoolMapper.getInstance().getStickyInformationForCurrentTransaction().execution()
+      Optional<ServiceReturn<CasualBuffer>> response2 = StickyTransactionHandler.handleTransactionSticky(service2,
+              factoriesSubsequentCall,
+              {con, execution -> con.tpcall(service2, ServiceBuffer.empty(), Flag.of(), execution)},
+              {TransactionPoolMapper.getInstance()})
+      then:
+      response2.get().errorState == ErrorState.OK
+      TransactionPoolMapper.getInstance().getNumberOfTrackedTransactions() == 1
+      TransactionPoolMapper.getInstance().getStickyInformationForCurrentTransaction().poolName() == poolName
+      TransactionPoolMapper.getInstance().getStickyInformationForCurrentTransaction().execution() == sharedExecution
+   }
+
+   private ConnectionFactoryEntry getFactoryMockServiceReturn(String jndiName, ServiceReturn<CasualBuffer> expectedReturn, long expectedCalls)
+   {
+      CasualConnection connection = Mock(CasualConnection)
+      expectedCalls * connection.tpcall(*_) >> expectedReturn
+
+      CasualConnectionFactory connectionFactory = Mock(CasualConnectionFactory)
+      expectedCalls * connectionFactory.getConnection() >> connection
+
+      ConnectionFactoryEntry connectionFactoryEntry = Mock(ConnectionFactoryEntry)
+      connectionFactoryEntry.isValid() >> true
+      connectionFactoryEntry.isInvalid() >> false
+      connectionFactoryEntry.getJndiName() >> jndiName
+      connectionFactoryEntry.getConnectionFactory() >> connectionFactory
+
+      return connectionFactoryEntry
+   }
+
+   def enableTransactionStickyForTest()
+   {
+      def transactionManager = Mock(TransactionManager)
+      def transaction = new TransactionImpl(Status.STATUS_ACTIVE)
+      transactionManager.getTransaction() >> {
+         transaction
+      }
+      TransactionPoolMapper.getInstance().setActiveForTest(true)
+      TransactionPoolMapper.getInstance().setTransactionManager(transactionManager)
+   }
+
+}

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/TpCallerFailoverTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/TpCallerFailoverTest.groovy
@@ -112,8 +112,8 @@ class TpCallerFailoverTest extends Specification
 
         then:
         1 * conFacHigh.getConnection() >> {exception()}
-        0 * conHigh.tpcall(serviceName, data, flags) >> {throw new RuntimeException("This should not happen because getConnection should fail")}
-        1 * conLow.tpcall(serviceName, data, flags) >> someServiceReturn
+        0 * conHigh.tpcall(serviceName, data, flags, _ as UUID) >> {throw new RuntimeException("This should not happen because getConnection should fail")}
+        1 * conLow.tpcall(serviceName, data, flags, _ as UUID) >> someServiceReturn
         result == someServiceReturn
 
         where:
@@ -225,7 +225,7 @@ class TpCallerFailoverTest extends Specification
 
         then:
         (priorities*entriesPerPriority) * conFacHigh.getConnection() >> {throw new ResourceException(failMessage)}
-        (1) * conLow.tpcall(serviceName, data, flags) >> someServiceReturn
+        (1) * conLow.tpcall(serviceName, data, flags, _ as UUID) >> someServiceReturn
         result == someServiceReturn
     }
 
@@ -251,7 +251,7 @@ class TpCallerFailoverTest extends Specification
        def result = tpCaller.tpcall(serviceName, data, flags, lookupService)
        def subsequentResult = tpCaller.tpcall(serviceName, data, flags, lookupService)
        then:
-       3 * conLow.tpcall(serviceName, data, flags) >>> [someServiceReturn, tpenoentServiceReturn, someServiceReturn]
+       3 * conLow.tpcall(serviceName, data, flags, _ as UUID) >>> [someServiceReturn, tpenoentServiceReturn, someServiceReturn]
        !cache.get(serviceName).empty
        result == someServiceReturn
        subsequentResult == someServiceReturn

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/TransactionPoolMapperTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/TransactionPoolMapperTest.groovy
@@ -46,10 +46,10 @@ class TransactionPoolMapperTest extends Specification
         transactionManager.setCurrentTransaction(transaction)
 
         String actualPoolName = "hello, world!"
-        TransactionPoolMapper.getInstance().setPoolNameForCurrentTransaction(actualPoolName)
+        TransactionPoolMapper.getInstance().setStickyInformationForCurrentTransaction(actualPoolName)
 
         expect:
-        TransactionPoolMapper.getInstance().getPoolNameForCurrentTransaction() == actualPoolName
+        TransactionPoolMapper.getInstance().getStickyInformationForCurrentTransaction() == actualPoolName
         TransactionPoolMapper.getInstance().getNumberOfTrackedTransactions() == 1
     }
 
@@ -61,7 +61,7 @@ class TransactionPoolMapperTest extends Specification
         for (int i = 0; i < transactions; i++)
         {
             transactionManager.setCurrentTransaction(new TransactionImpl(Status.STATUS_ACTIVE))
-            TransactionPoolMapper.getInstance().setPoolNameForCurrentTransaction("hello transaction " + i)
+            TransactionPoolMapper.getInstance().setStickyInformationForCurrentTransaction("hello transaction " + i)
         }
 
         expect:
@@ -73,10 +73,10 @@ class TransactionPoolMapperTest extends Specification
         given:
         transactionManager.setCurrentTransaction(new TransactionImpl(Status.STATUS_ACTIVE))
 
-        TransactionPoolMapper.getInstance().setPoolNameForCurrentTransaction("eis/myPool")
+        TransactionPoolMapper.getInstance().setStickyInformationForCurrentTransaction("eis/myPool")
 
         when:
-        TransactionPoolMapper.getInstance().setPoolNameForCurrentTransaction("eis/whateverPool")
+        TransactionPoolMapper.getInstance().setStickyInformationForCurrentTransaction("eis/whateverPool")
 
         then:
         def e = thrown(CasualRuntimeException)

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/TransactionPoolMapperTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/TransactionPoolMapperTest.groovy
@@ -46,10 +46,13 @@ class TransactionPoolMapperTest extends Specification
         transactionManager.setCurrentTransaction(transaction)
 
         String actualPoolName = "hello, world!"
-        TransactionPoolMapper.getInstance().setStickyInformationForCurrentTransaction(actualPoolName)
+        UUID execution = UUID.randomUUID()
+        StickyInformation stickyInformation = new StickyInformation(actualPoolName, execution)
+        TransactionPoolMapper.getInstance().setStickyInformationForCurrentTransaction(stickyInformation)
 
         expect:
-        TransactionPoolMapper.getInstance().getStickyInformationForCurrentTransaction() == actualPoolName
+        TransactionPoolMapper.getInstance().getStickyInformationForCurrentTransaction().poolName() == actualPoolName
+        TransactionPoolMapper.getInstance().getStickyInformationForCurrentTransaction().execution() == execution
         TransactionPoolMapper.getInstance().getNumberOfTrackedTransactions() == 1
     }
 
@@ -61,7 +64,8 @@ class TransactionPoolMapperTest extends Specification
         for (int i = 0; i < transactions; i++)
         {
             transactionManager.setCurrentTransaction(new TransactionImpl(Status.STATUS_ACTIVE))
-            TransactionPoolMapper.getInstance().setStickyInformationForCurrentTransaction("hello transaction " + i)
+            StickyInformation stickyInformation = new StickyInformation("hello transaction " + i, UUID.randomUUID())
+            TransactionPoolMapper.getInstance().setStickyInformationForCurrentTransaction(stickyInformation)
         }
 
         expect:
@@ -73,10 +77,11 @@ class TransactionPoolMapperTest extends Specification
         given:
         transactionManager.setCurrentTransaction(new TransactionImpl(Status.STATUS_ACTIVE))
 
-        TransactionPoolMapper.getInstance().setStickyInformationForCurrentTransaction("eis/myPool")
+        StickyInformation stickyInformation = new StickyInformation("eis/myPool", UUID.randomUUID())
+        TransactionPoolMapper.getInstance().setStickyInformationForCurrentTransaction(stickyInformation)
 
         when:
-        TransactionPoolMapper.getInstance().setStickyInformationForCurrentTransaction("eis/whateverPool")
+        TransactionPoolMapper.getInstance().setStickyInformationForCurrentTransaction(new StickyInformation("eis/whateverPool", UUID.randomUUID()))
 
         then:
         def e = thrown(CasualRuntimeException)

--- a/casual/casual-caller/src/test/java/se/laz/casual/connection/caller/TransactionManagerImpl.java
+++ b/casual/casual-caller/src/test/java/se/laz/casual/connection/caller/TransactionManagerImpl.java
@@ -19,11 +19,6 @@ public class TransactionManagerImpl implements TransactionManager
 {
     private Transaction currentTransaction;
 
-    public Transaction getCurrentTransaction()
-    {
-        return currentTransaction;
-    }
-
     public void setCurrentTransaction(Transaction currentTransaction)
     {
         this.currentTransaction = currentTransaction;

--- a/versions.gradle
+++ b/versions.gradle
@@ -9,7 +9,7 @@
 group = 'se.laz.casual'
 version = '3.2.19'
 
-def casual_jca_version = '3.2.42'
+def casual_jca_version = '3.2.44-SNAPSHOT'
 def gson_version = '2.10.1'
 
 ext.libs = [

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '3.2.19'
+version = '3.2.20'
 
 def casual_jca_version = '3.2.44-SNAPSHOT'
 def gson_version = '2.10.1'

--- a/versions.gradle
+++ b/versions.gradle
@@ -9,7 +9,7 @@
 group = 'se.laz.casual'
 version = '3.2.20'
 
-def casual_jca_version = '3.2.44-SNAPSHOT'
+def casual_jca_version = '3.2.44'
 def gson_version = '2.10.1'
 
 ext.libs = [


### PR DESCRIPTION
When sticky is being used, tp(a)calls in the same transaction will use the same execution.

This will help with traceability.