### PR TITLE
Feature/2.2/execution sticky (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Casual caller provides an abstraction for outbound connections on top of casual-
 
 This is just a convenience layer for applications to make use, it does not in any way impact the casual-jca implementation.
 
+## casual jca version dependency
+```casual-caller``` v2.2.20+ needs ```casual-jca``` version 2.2.34+
 
 ## Requirements on setup of connection pools
 

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/CasualCallerImpl.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/CasualCallerImpl.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 import javax.resource.ResourceException;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 @Remote(CasualCaller.class)
@@ -63,10 +64,22 @@ public class CasualCallerImpl implements CasualCaller
     }
 
     @Override
+    public ServiceReturn<CasualBuffer> tpcall(String s, CasualBuffer casualBuffer, Flag<AtmiFlags> flag, UUID execution)
+    {
+        throw new UnsupportedOperationException("Casual caller does not support tpcall with execution");
+    }
+
+    @Override
     public CompletableFuture<Optional<ServiceReturn<CasualBuffer>>> tpacall(String serviceName, CasualBuffer data, Flag<AtmiFlags> flags)
     {
         failedDomainDiscoveryHandler.issueDomainDiscoveryAndRepopulateCache();
         return flags.isSet(AtmiFlags.TPNOTRAN) ? transactionLess.tpacall(() -> tpCaller.tpacall(serviceName, data, flags, lookup)) : tpCaller.tpacall(serviceName, data, flags, lookup);
+    }
+
+    @Override
+    public CompletableFuture<Optional<ServiceReturn<CasualBuffer>>> tpacall(String s, CasualBuffer casualBuffer, Flag<AtmiFlags> flag, UUID uuid)
+    {
+        throw new UnsupportedOperationException("Casual caller does not support tpacall with execution");
     }
 
     @Override

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/FailoverAlgorithm.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/FailoverAlgorithm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 - 2023, The casual project. All rights reserved.
+ * Copyright (c) 2021 - 2024, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -9,6 +9,8 @@ package se.laz.casual.connection.caller;
 import se.laz.casual.api.buffer.CasualBuffer;
 import se.laz.casual.api.buffer.ServiceReturn;
 import se.laz.casual.api.flags.ErrorState;
+import se.laz.casual.connection.caller.functions.FunctionNoArg;
+import se.laz.casual.connection.caller.functions.FunctionThrowsResourceException;
 import se.laz.casual.jca.CasualConnection;
 import se.laz.casual.network.connection.CasualConnectionException;
 import se.laz.casual.network.connection.DomainDisconnectedException;
@@ -16,6 +18,7 @@ import se.laz.casual.network.connection.DomainDisconnectedException;
 import javax.resource.ResourceException;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -28,7 +31,7 @@ public class FailoverAlgorithm
     public ServiceReturn<CasualBuffer> tpcallWithFailover(
             String serviceName,
             ConnectionFactoryLookup lookup,
-            FunctionThrowsResourceException<CasualConnection, ServiceReturn<CasualBuffer>> doCall,
+            FunctionThrowsResourceException<ServiceReturn<CasualBuffer>> doCall,
             FunctionNoArg<ServiceReturn<CasualBuffer>> doTpenoent)
     {
         List<ConnectionFactoryEntry> validEntries = getFoundAndValidEntries(lookup, serviceName);
@@ -62,7 +65,7 @@ public class FailoverAlgorithm
     public CompletableFuture<Optional<ServiceReturn<CasualBuffer>>> tpacallWithFailover(
             String serviceName,
             ConnectionFactoryLookup lookup,
-            FunctionThrowsResourceException<CasualConnection, CompletableFuture<Optional<ServiceReturn<CasualBuffer>>>> doCall,
+            FunctionThrowsResourceException<CompletableFuture<Optional<ServiceReturn<CasualBuffer>>>> doCall,
             FunctionNoArg<CompletableFuture<Optional<ServiceReturn<CasualBuffer>>>> doTpenoent)
     {
         List<ConnectionFactoryEntry> validEntries = getFoundAndValidEntries(lookup, serviceName);
@@ -85,14 +88,14 @@ public class FailoverAlgorithm
         return validEntries;
     }
 
-    private <T> T issueCall(String serviceName, List<ConnectionFactoryEntry> validEntries, FunctionThrowsResourceException<CasualConnection, T> doCall)
+    private <T> T issueCall(String serviceName, List<ConnectionFactoryEntry> validEntries, FunctionThrowsResourceException<T> doCall)
     {
         Exception thrownException = null;
 
         // Sticky transaction handling
         try
         {
-            Optional<T> stickyMaybe = handleTransactionSticky(serviceName, validEntries, doCall);
+            Optional<T> stickyMaybe = StickyTransactionHandler.handleTransactionSticky(serviceName, validEntries, doCall, TransactionPoolMapper::getInstance);
 
             if (stickyMaybe.isPresent())
             {
@@ -110,7 +113,7 @@ public class FailoverAlgorithm
         {
             try (CasualConnection con = connectionFactoryEntry.getConnectionFactory().getConnection())
             {
-                return doCall.apply(con);
+                return doCall.apply(con, UUID.randomUUID());
             }
             catch (CasualConnectionException e)
             {
@@ -135,100 +138,4 @@ public class FailoverAlgorithm
         throw new CasualResourceException("Call failed to all " + validEntries.size() + " available casual connections.", thrownException);
     }
 
-    /**
-     * Try to use a stickied pool if pool stickiness is configured and any stickied pool is available and serves the requested service
-     *
-     * @param serviceName Service to call
-     * @param factories   Currently available factories for service to call
-     * @param doCall      Provided service call procedure
-     * @return Optional ServiceReturn. An empty result could indicate that stickiness isn't enabled, sticky isn't set yet for the current transaction (which will be the case for the first call) or the stickied pool was unavailable so call to sticky was skipped. Empty should always lead to retry down the line if possible, otherwise a TPENOENT response.
-     * @throws ResourceException Some softer errors are reported as resource exceptions. If these are thrown later retries with other pools is possible.
-     */
-    private <T> Optional<T> handleTransactionSticky(
-            String serviceName,
-            List<ConnectionFactoryEntry> factories,
-            FunctionThrowsResourceException<CasualConnection, T> doCall) throws ResourceException
-    {
-        if (!TransactionPoolMapper.getInstance().isPoolMappingActive())
-        {
-            return Optional.empty();
-        }
-
-        Optional<ConnectionFactoryEntry> stickyFactoryMaybe = getAndSetSticky(serviceName, factories);
-
-        if (stickyFactoryMaybe.isPresent())
-        {
-            // We have a specific stickied pool to use that looks usable, try to use it
-            ConnectionFactoryEntry connectionFactoryEntry = stickyFactoryMaybe.get();
-            factories.remove(connectionFactoryEntry); // If we later need to do failover stuff we don't want to retry with this one
-            LOG.finest(() -> "Attempting to use pool=" + connectionFactoryEntry.getJndiName() + " with sticky to current transaction.");
-
-            try (CasualConnection con = connectionFactoryEntry.getConnectionFactory().getConnection())
-            {
-                return Optional.of(doCall.apply(con));
-            }
-            catch (CasualConnectionException e)
-            {
-                //This error branch will most likely happen if there are connection errors during a service call
-                connectionFactoryEntry.invalidate();
-
-                // These exceptions are rollback-only, do not attempt any retries.
-                throw new CasualResourceException("Call failed during execution to service=" + serviceName
-                        + " on connection=" + connectionFactoryEntry.getJndiName()
-                        + " because of a network connection error, retries not possible.", e);
-            }
-        }
-        else
-        {
-            LOG.finest(() -> "Current sticky is " + TransactionPoolMapper.getInstance().getPoolNameForCurrentTransaction()
-                    + " but called service=" + serviceName
-                    + " is currently available in pools [" + factories.stream().map(ConnectionFactoryEntry::getJndiName).collect(Collectors.joining(","))
-                    + "]. Will use available pools instead of stickied pool.");
-            return Optional.empty();
-        }
-    }
-
-    private Optional<ConnectionFactoryEntry> getAndSetSticky(String serviceName, List<ConnectionFactoryEntry> validFactories)
-    {
-        String transactionPoolName = TransactionPoolMapper.getInstance().getPoolNameForCurrentTransaction();
-
-        if (transactionPoolName == null)
-        {
-            // Service exists in some pool, pick first one as sticky (would otherwise be picked later in normal flow)
-            ConnectionFactoryEntry newStickyFactory = validFactories.get(0);
-            TransactionPoolMapper.getInstance().setPoolNameForCurrentTransaction(newStickyFactory.getJndiName());
-            LOG.finest(() -> "No sticky present for call to service=" + serviceName + ", setting sticky=" + newStickyFactory.getJndiName());
-            return Optional.of(newStickyFactory);
-        }
-        else
-        {
-            Optional<ConnectionFactoryEntry> stickyMatch = validFactories
-                    .stream()
-                    .filter(connectionFactoryEntry -> transactionPoolName.equals(connectionFactoryEntry.getJndiName()) && connectionFactoryEntry.isValid())
-                    .findFirst();
-
-            if (stickyMatch.isPresent())
-            {
-                LOG.finest(() -> "Using stickied pool=" + transactionPoolName + " for call to service=" + serviceName);
-                validFactories.remove(stickyMatch.get());
-                return stickyMatch;
-            }
-            else
-            {
-                LOG.finest(() -> "There was a sticky=" + transactionPoolName + ", but it did not match the valid factories for the called service=" + serviceName);
-                return Optional.empty();
-            }
-        }
-    }
-
-
-    public interface FunctionNoArg<R>
-    {
-        R apply();
-    }
-
-    public interface FunctionThrowsResourceException<I, R>
-    {
-        R apply(I input) throws ResourceException;
-    }
 }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/StickiedCallInfo.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/StickiedCallInfo.java
@@ -1,0 +1,62 @@
+package se.laz.casual.connection.caller;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public class StickiedCallInfo
+{
+    private final ConnectionFactoryEntry connectionFactoryEntry;
+    private final UUID execution;
+    private StickiedCallInfo(ConnectionFactoryEntry connectionFactoryEntry, UUID execution)
+    {
+        this.connectionFactoryEntry = connectionFactoryEntry;
+        this.execution = execution;
+    }
+
+    public static StickiedCallInfo of(ConnectionFactoryEntry connectionFactoryEntry, UUID execution)
+    {
+        Objects.requireNonNull(connectionFactoryEntry, "connectionFactoryEntry can not be null");
+        Objects.requireNonNull(execution, "execution can not be null");
+        return new StickiedCallInfo(connectionFactoryEntry, execution);
+    }
+
+    public ConnectionFactoryEntry getConnectionFactoryEntry()
+    {
+        return connectionFactoryEntry;
+    }
+
+    public UUID getExecution()
+    {
+        return execution;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (!(o instanceof StickiedCallInfo))
+        {
+            return false;
+        }
+        StickiedCallInfo that = (StickiedCallInfo) o;
+        return Objects.equals(connectionFactoryEntry, that.connectionFactoryEntry) && Objects.equals(execution, that.execution);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(connectionFactoryEntry, execution);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "StickiedCallInfo{" +
+                "connectionFactoryEntry=" + connectionFactoryEntry +
+                ", execution=" + execution +
+                '}';
+    }
+}

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/StickyInformation.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/StickyInformation.java
@@ -1,0 +1,56 @@
+package se.laz.casual.connection.caller;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public class StickyInformation
+{
+    private final String poolName;
+    private final UUID execution;
+    private StickyInformation(String poolName, UUID execution)
+    {
+        this.poolName = poolName;
+        this.execution = execution;
+    }
+    public static StickyInformation of(String poolName, UUID execution)
+    {
+        Objects.requireNonNull(poolName, "poolName can not be null");
+        Objects.requireNonNull(execution, "execution can not be null");
+        return new StickyInformation(poolName, execution);
+    }
+    public String getPoolName()
+    {
+        return poolName;
+    }
+    public UUID getExecution()
+    {
+        return execution;
+    }
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (!(o instanceof StickyInformation))
+        {
+            return false;
+        }
+        StickyInformation that = (StickyInformation) o;
+        return Objects.equals(poolName, that.poolName) && Objects.equals(execution, that.execution);
+    }
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(poolName, execution);
+    }
+    @Override
+    public String toString()
+    {
+        return "StickyInformation{" +
+                "poolName='" + poolName + '\'' +
+                ", execution=" + execution +
+                '}';
+    }
+}

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/StickyTransactionHandler.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/StickyTransactionHandler.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2021 - 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+package se.laz.casual.connection.caller;
+
+import se.laz.casual.connection.caller.functions.FunctionThrowsResourceException;
+import se.laz.casual.jca.CasualConnection;
+import se.laz.casual.network.connection.CasualConnectionException;
+
+import javax.resource.ResourceException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+public class StickyTransactionHandler
+{
+    private static final Logger LOG = Logger.getLogger(StickyTransactionHandler.class.getName());
+
+    private StickyTransactionHandler()
+    {}
+    /**
+     * Try to use a stickied pool if pool stickiness is configured and any stickied pool is available and serves the requested service
+     *
+     * @param serviceName Service to call
+     * @param factories   Currently available factories for service to call
+     * @param doCall      Provided service call procedure
+     * @return Optional ServiceReturn. An empty result could indicate that stickiness isn't enabled, sticky isn't set yet for the current transaction (which will be the case for the first call) or the stickied pool was unavailable so call to sticky was skipped. Empty should always lead to retry down the line if possible, otherwise a TPENOENT response.
+     * @throws ResourceException Some softer errors are reported as resource exceptions. If these are thrown later retries with other pools is possible.
+     */
+    public static <T> Optional<T> handleTransactionSticky(
+            String serviceName,
+            List<ConnectionFactoryEntry> factories,
+            FunctionThrowsResourceException<T> doCall,
+            Supplier<TransactionPoolMapper> transactionPoolMapperSupplier) throws ResourceException
+    {
+        if (!transactionPoolMapperSupplier.get().isPoolMappingActive())
+        {
+            return Optional.empty();
+        }
+
+        Optional<StickiedCallInfo> stickyMaybe = getAndSetSticky(serviceName, factories, transactionPoolMapperSupplier);
+
+        if (stickyMaybe.isPresent())
+        {
+            // We have a specific stickied pool to use that looks usable, try to use it
+            StickiedCallInfo sticky = stickyMaybe.get();
+            factories.remove(sticky.getConnectionFactoryEntry()); // If we later need to do failover stuff we don't want to retry with this one
+            LOG.finest(() -> "Attempting to use pool=" + sticky.getConnectionFactoryEntry().getJndiName() + " with sticky to current transaction.");
+            try (CasualConnection con = sticky.getConnectionFactoryEntry().getConnectionFactory().getConnection())
+            {
+                return Optional.of(doCall.apply(con, sticky.getExecution()));
+            }
+            catch (CasualConnectionException e)
+            {
+                //This error branch will most likely happen if there are connection errors during a service call
+                sticky.getConnectionFactoryEntry().invalidate();
+
+                // These exceptions are rollback-only, do not attempt any retries.
+                throw new CasualResourceException("Call failed during execution to service=" + serviceName
+                        + " on connection=" + sticky.getConnectionFactoryEntry().getJndiName()
+                        + " because of a network connection error, retries not possible.", e);
+            }
+        }
+        else
+        {
+            LOG.finest(() -> "Current sticky is " + transactionPoolMapperSupplier.get().getStickyInformationForCurrentTransaction()
+                    + " but called service=" + serviceName
+                    + " is currently available in pools [" + factories.stream().map(ConnectionFactoryEntry::getJndiName).collect(Collectors.joining(","))
+                    + "]. Will use available pools instead of stickied pool.");
+            return Optional.empty();
+        }
+    }
+
+    private static Optional<StickiedCallInfo> getAndSetSticky(String serviceName, List<ConnectionFactoryEntry> validFactories, Supplier<TransactionPoolMapper> transactionPoolMapperSupplier)
+    {
+        StickyInformation stickyInformation = transactionPoolMapperSupplier.get().getStickyInformationForCurrentTransaction();
+
+        if (stickyInformation == null)
+        {
+            // Service exists in some pool, pick first one as sticky (would otherwise be picked later in normal flow)
+            ConnectionFactoryEntry newStickyFactory = validFactories.get(0);
+            StickyInformation newStickyInformation =  StickyInformation.of(newStickyFactory.getJndiName(), UUID.randomUUID());
+            transactionPoolMapperSupplier.get().setStickyInformationForCurrentTransaction(newStickyInformation);
+            LOG.finest(() -> "No sticky present for call to service=" + serviceName + ", setting sticky=" + newStickyFactory.getJndiName() + " with=" + newStickyInformation);
+            return Optional.of(StickiedCallInfo.of(newStickyFactory, newStickyInformation.getExecution()));
+        }
+        else
+        {
+            Optional<ConnectionFactoryEntry> stickyMatch = validFactories
+                    .stream()
+                    .filter(connectionFactoryEntry -> stickyInformation.getPoolName().equals(connectionFactoryEntry.getJndiName()) && connectionFactoryEntry.isValid())
+                    .findFirst();
+
+            if (stickyMatch.isPresent())
+            {
+                LOG.finest(() -> "Using stickied pool=" + stickyInformation + " for call to service=" + serviceName);
+                ConnectionFactoryEntry stickyEntry = stickyMatch.get();
+                validFactories.remove(stickyEntry);
+                return Optional.of(StickiedCallInfo.of(stickyEntry, stickyInformation.getExecution()));
+            }
+            else
+            {
+                LOG.finest(() -> "There was a sticky=" + stickyInformation + ", but it did not match the valid factories for the called service=" + serviceName);
+                return Optional.empty();
+            }
+        }
+    }
+}

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/TpCaller.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/TpCaller.java
@@ -17,6 +17,5 @@ import java.util.concurrent.CompletableFuture;
 public interface TpCaller
 {
     ServiceReturn<CasualBuffer> tpcall(String serviceName, CasualBuffer data, Flag<AtmiFlags> flags, ConnectionFactoryLookup lookup);
-
     CompletableFuture<Optional<ServiceReturn<CasualBuffer>>> tpacall(String serviceName, CasualBuffer data, Flag<AtmiFlags> flags, ConnectionFactoryLookup lookup);
 }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/TpCallerFailover.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/TpCallerFailover.java
@@ -38,7 +38,7 @@ public class TpCallerFailover implements TpCaller
                 serviceName,
                 lookup,
                 // How to call service
-                con -> con.tpcall(serviceName, data, flags),
+                (con, execution) -> con.tpcall(serviceName, data, flags, execution),
                 // What to do if the cache has no entries
                 this::tpenoentReply
         );
@@ -51,7 +51,7 @@ public class TpCallerFailover implements TpCaller
                 serviceName,
                 lookup,
                 // How to call service
-                con -> con.tpacall(serviceName, data, flags),
+                (con, execution) -> con.tpacall(serviceName, data, flags, execution),
                 // What to do if the cache has no entries
                 () -> CompletableFuture.supplyAsync(this::optionalTpenoentReply)
         );

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/TransactionPoolMapper.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/TransactionPoolMapper.java
@@ -24,10 +24,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-public final class TransactionPoolMapper
+public class TransactionPoolMapper
 {
     private static final Logger LOG = Logger.getLogger(TransactionPoolMapper.class.getName());
-    private final Map<Transaction, String> transactionStickies = new ConcurrentHashMap<>();
+    private final Map<Transaction, StickyInformation> transactionStickies = new ConcurrentHashMap<>();
 
     private boolean stickyEnabled = ConfigurationService.getInstance().getConfiguration().isTransactionStickyEnabled();
     private final Object lock = new Object();
@@ -69,7 +69,7 @@ public final class TransactionPoolMapper
         return instance;
     }
 
-    public String getPoolNameForCurrentTransaction()
+    public StickyInformation getStickyInformationForCurrentTransaction()
     {
         if (!stickyEnabled)
         {
@@ -80,7 +80,7 @@ public final class TransactionPoolMapper
         return transactionMaybe.map(transactionStickies::get).orElse(null);
     }
 
-    public void setPoolNameForCurrentTransaction(String poolName)
+    public void setStickyInformationForCurrentTransaction(StickyInformation stickyInformation)
     {
         if (!stickyEnabled)
         {
@@ -96,12 +96,12 @@ public final class TransactionPoolMapper
                 if (transactionStickies.containsKey(transaction))
                 {
                     throw new CasualRuntimeException("Attempted to set a pool sticky ("
-                            + poolName + ") for a transaction that was already stickied to another pool ("
+                            + stickyInformation + ") for a transaction that was already stickied to another pool ("
                             + transactionStickies.get(transaction) + ").");
                 }
                 else
                 {
-                    transactionStickies.put(transaction, poolName);
+                    transactionStickies.put(transaction, stickyInformation);
                     ensureTransactionPruningOnCompletion(transaction);
                 }
             }
@@ -177,7 +177,7 @@ public final class TransactionPoolMapper
     public int getNumberOfTrackedTransactions(String poolName)
     {
         Objects.requireNonNull(poolName, "poolName must have a value");
-        return (int) transactionStickies.values().stream().filter(s -> s.equals(poolName)).count();
+        return (int) transactionStickies.values().stream().filter(s -> s.getPoolName().equals(poolName)).count();
     }
 
     /**
@@ -214,8 +214,8 @@ public final class TransactionPoolMapper
             Set<Transaction> keys = transactionStickies.keySet();
             for (Transaction key : keys)
             {
-                String entry = transactionStickies.get(key);
-                if (poolName.equals(entry))
+                StickyInformation entry = transactionStickies.get(key);
+                if (poolName.equals(entry.getPoolName()))
                 {
                     transactionStickies.remove(key);
                 }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/functions/FunctionNoArg.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/functions/FunctionNoArg.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2021 - 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+package se.laz.casual.connection.caller.functions;
+
+@FunctionalInterface
+public interface FunctionNoArg<R>
+{
+    R apply();
+}

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/functions/FunctionThrowsResourceException.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/functions/FunctionThrowsResourceException.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2021 - 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+package se.laz.casual.connection.caller.functions;
+
+import javax.resource.ResourceException;
+import se.laz.casual.jca.CasualConnection;
+
+import java.util.UUID;
+
+@FunctionalInterface
+public interface FunctionThrowsResourceException <R>
+{
+    R apply(CasualConnection connection, UUID execution) throws ResourceException;
+}

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/CasualCallerImplTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/CasualCallerImplTest.groovy
@@ -220,7 +220,7 @@ class CasualCallerImplTest extends Specification
         def flags = Flag.of(AtmiFlags.NOFLAG)
         connectionFactory.getConnection() >> {
             def connection = Mock(CasualConnection)
-            1 * connection.tpcall(serviceName, callingBuffer, flags) >> serviceReturn
+            1 * connection.tpcall(serviceName, callingBuffer, flags, _ as UUID) >> serviceReturn
             return connection
         }
         def producer = Mock(ConnectionFactoryProducer){
@@ -251,7 +251,7 @@ class CasualCallerImplTest extends Specification
         def flags = Flag.of(AtmiFlags.NOFLAG)
         connectionFactory.getConnection() >> {
             def connection = Mock(CasualConnection)
-            1 * connection.tpacall(serviceName, callingBuffer, flags) >> future
+            1 * connection.tpacall(serviceName, callingBuffer, flags, _ as UUID) >> future
             return connection
         }
         def producer = Mock(ConnectionFactoryProducer){

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/FailoverAlgorithmTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/FailoverAlgorithmTest.groovy
@@ -74,7 +74,7 @@ class FailoverAlgorithmTest extends Specification
       ServiceReturn<CasualBuffer> response = failoverAlgorithm.tpcallWithFailover(
               service,
               lookup,
-              {con -> con.tpcall(service, ServiceBuffer.empty(), Flag.of())},
+              {con,execution -> con.tpcall(service, ServiceBuffer.empty(), Flag.of(), execution)},
               {serviceReturnTpenoent})
 
       then:
@@ -104,7 +104,7 @@ class FailoverAlgorithmTest extends Specification
       ServiceReturn<CasualBuffer> response = failoverAlgorithm.tpcallWithFailover(
               service,
               lookup,
-              {con -> con.tpcall(service, ServiceBuffer.empty(), Flag.of())},
+              {con, execution -> con.tpcall(service, ServiceBuffer.empty(), Flag.of(), execution)},
               {serviceReturnTpenoent})
 
       then:
@@ -134,7 +134,7 @@ class FailoverAlgorithmTest extends Specification
       ServiceReturn<CasualBuffer> response = failoverAlgorithm.tpcallWithFailover(
               service,
               lookup,
-              {con -> con.tpcall(service, ServiceBuffer.empty(), Flag.of())},
+              {con, execution -> con.tpcall(service, ServiceBuffer.empty(), Flag.of(), execution)},
               {serviceReturnTpenoent})
 
       then:
@@ -169,13 +169,13 @@ class FailoverAlgorithmTest extends Specification
       ServiceReturn<CasualBuffer> response1 = failoverAlgorithm.tpcallWithFailover(
               service1,
               lookup,
-              {con -> con.tpcall(service1, ServiceBuffer.empty(), Flag.of())},
+              {con, execution -> con.tpcall(service1, ServiceBuffer.empty(), Flag.of(), execution)},
               {serviceReturnTpenoent})
 
       ServiceReturn<CasualBuffer> response2 = failoverAlgorithm.tpcallWithFailover(
               service2,
               lookup,
-              {con -> con.tpcall(service2, ServiceBuffer.empty(), Flag.of())},
+              {con, execution -> con.tpcall(service2, ServiceBuffer.empty(), Flag.of(), execution)},
               {serviceReturnTpenoent})
 
       then:
@@ -183,7 +183,7 @@ class FailoverAlgorithmTest extends Specification
       response2.errorState == ErrorState.OK
 
       TransactionPoolMapper.getInstance().getNumberOfTrackedTransactions() == 1
-      TransactionPoolMapper.getInstance().getPoolNameForCurrentTransaction() == pool1name
+      TransactionPoolMapper.getInstance().getStickyInformationForCurrentTransaction().getPoolName() == pool1name
    }
 
    def 'stickies, failover: when calling stickied service failover is possible to other non-stickied pool'()
@@ -209,13 +209,13 @@ class FailoverAlgorithmTest extends Specification
       ServiceReturn<CasualBuffer> response1 = failoverAlgorithm.tpcallWithFailover(
               service1,
               lookup,
-              {con -> con.tpcall(service1, ServiceBuffer.empty(), Flag.of())},
+              {con, execution -> con.tpcall(service1, ServiceBuffer.empty(), Flag.of(), execution)},
               {serviceReturnTpenoent})
 
       then:
       response1.errorState == ErrorState.OK
       TransactionPoolMapper.getInstance().getNumberOfTrackedTransactions() == 1
-      TransactionPoolMapper.getInstance().getPoolNameForCurrentTransaction() == pool1name
+      TransactionPoolMapper.getInstance().getStickyInformationForCurrentTransaction().getPoolName() == pool1name
    }
 
    private ConnectionFactoryEntry getFactoryMockServiceReturn(String jndiName, ServiceReturn<CasualBuffer> expectedReturn)

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/StickyTransactionHandlerTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/StickyTransactionHandlerTest.groovy
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+package se.laz.casual.connection.caller
+
+import javax.transaction.Status
+import javax.transaction.TransactionManager
+import se.laz.casual.api.buffer.CasualBuffer
+import se.laz.casual.api.buffer.ServiceReturn
+import se.laz.casual.api.buffer.type.ServiceBuffer
+import se.laz.casual.api.flags.ErrorState
+import se.laz.casual.api.flags.Flag
+import se.laz.casual.api.flags.ServiceReturnState
+import se.laz.casual.jca.CasualConnection
+import se.laz.casual.jca.CasualConnectionFactory
+import spock.lang.Shared
+import spock.lang.Specification
+
+class StickyTransactionHandlerTest extends Specification
+{
+   @Shared
+   ServiceReturn<CasualBuffer> serviceReturnSuccess = new ServiceReturn<>(ServiceBuffer.empty(), ServiceReturnState.TPSUCCESS, ErrorState.OK, 0L)
+
+   def cleanup()
+   {
+      TransactionPoolMapper.resetForTest()
+   }
+
+   def 'sticky not active'()
+   {
+      given:
+      TransactionPoolMapper mapper = Mock(TransactionPoolMapper){
+         isPoolMappingActive() >> false
+      }
+      when:
+      Optional result = StickyTransactionHandler.handleTransactionSticky('serviceOne', [], {con, execution -> }, () -> mapper)
+      then:
+      result.isEmpty()
+   }
+
+   def '2 calls in the same transaction, sticky - should use the same connection and execution'()
+   {
+      given:
+      enableTransactionStickyForTest()
+      def poolName = "eis/pool-one"
+      def expectedNumberOfCalls = 2
+      def connectionFactory = getFactoryMockServiceReturn(poolName, serviceReturnSuccess, expectedNumberOfCalls)
+      def factories = [connectionFactory]
+      def factoriesSubsequentCall = [connectionFactory]
+      def service1 = "service1"
+      def service2 = "service2"
+      when:
+      Optional<ServiceReturn<CasualBuffer>> response = StickyTransactionHandler.handleTransactionSticky(service1,
+              factories,
+              {con, execution -> con.tpcall(service1, ServiceBuffer.empty(), Flag.of(), execution)},
+              {TransactionPoolMapper.getInstance()})
+      then:
+      response.get().errorState == ErrorState.OK
+      TransactionPoolMapper.getInstance().getNumberOfTrackedTransactions() == 1
+      TransactionPoolMapper.getInstance().getStickyInformationForCurrentTransaction().getPoolName() == poolName
+      when:
+      UUID sharedExecution = TransactionPoolMapper.getInstance().getStickyInformationForCurrentTransaction().getExecution()
+      Optional<ServiceReturn<CasualBuffer>> response2 = StickyTransactionHandler.handleTransactionSticky(service2,
+              factoriesSubsequentCall,
+              {con, execution -> con.tpcall(service2, ServiceBuffer.empty(), Flag.of(), execution)},
+              {TransactionPoolMapper.getInstance()})
+      then:
+      response2.get().errorState == ErrorState.OK
+      TransactionPoolMapper.getInstance().getNumberOfTrackedTransactions() == 1
+      TransactionPoolMapper.getInstance().getStickyInformationForCurrentTransaction().getPoolName() == poolName
+      TransactionPoolMapper.getInstance().getStickyInformationForCurrentTransaction().getExecution() == sharedExecution
+   }
+
+   private ConnectionFactoryEntry getFactoryMockServiceReturn(String jndiName, ServiceReturn<CasualBuffer> expectedReturn, long expectedCalls)
+   {
+      CasualConnection connection = Mock(CasualConnection)
+      expectedCalls * connection.tpcall(*_) >> expectedReturn
+
+      CasualConnectionFactory connectionFactory = Mock(CasualConnectionFactory)
+      expectedCalls * connectionFactory.getConnection() >> connection
+
+      ConnectionFactoryEntry connectionFactoryEntry = Mock(ConnectionFactoryEntry)
+      connectionFactoryEntry.isValid() >> true
+      connectionFactoryEntry.isInvalid() >> false
+      connectionFactoryEntry.getJndiName() >> jndiName
+      connectionFactoryEntry.getConnectionFactory() >> connectionFactory
+
+      return connectionFactoryEntry
+   }
+
+   def enableTransactionStickyForTest()
+   {
+      def transactionManager = Mock(TransactionManager)
+      def transaction = new TransactionImpl(Status.STATUS_ACTIVE)
+      transactionManager.getTransaction() >> {
+         transaction
+      }
+      TransactionPoolMapper.getInstance().setActiveForTest(true)
+      TransactionPoolMapper.getInstance().setTransactionManager(transactionManager)
+   }
+
+}

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/TransactionPoolMapperTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/TransactionPoolMapperTest.groovy
@@ -46,10 +46,13 @@ class TransactionPoolMapperTest extends Specification
         transactionManager.setCurrentTransaction(transaction)
 
         String actualPoolName = "hello, world!"
-        TransactionPoolMapper.getInstance().setPoolNameForCurrentTransaction(actualPoolName)
+        UUID execution = UUID.randomUUID()
+        StickyInformation stickyInformation = new StickyInformation(actualPoolName, execution)
+        TransactionPoolMapper.getInstance().setStickyInformationForCurrentTransaction(stickyInformation)
 
         expect:
-        TransactionPoolMapper.getInstance().getPoolNameForCurrentTransaction() == actualPoolName
+        TransactionPoolMapper.getInstance().getStickyInformationForCurrentTransaction().getPoolName() == actualPoolName
+        TransactionPoolMapper.getInstance().getStickyInformationForCurrentTransaction().getExecution() == execution
         TransactionPoolMapper.getInstance().getNumberOfTrackedTransactions() == 1
     }
 
@@ -61,7 +64,8 @@ class TransactionPoolMapperTest extends Specification
         for (int i = 0; i < transactions; i++)
         {
             transactionManager.setCurrentTransaction(new TransactionImpl(Status.STATUS_ACTIVE))
-            TransactionPoolMapper.getInstance().setPoolNameForCurrentTransaction("hello transaction " + i)
+            StickyInformation stickyInformation = new StickyInformation("hello transaction " + i, UUID.randomUUID())
+            TransactionPoolMapper.getInstance().setStickyInformationForCurrentTransaction(stickyInformation)
         }
 
         expect:
@@ -73,10 +77,11 @@ class TransactionPoolMapperTest extends Specification
         given:
         transactionManager.setCurrentTransaction(new TransactionImpl(Status.STATUS_ACTIVE))
 
-        TransactionPoolMapper.getInstance().setPoolNameForCurrentTransaction("eis/myPool")
+        StickyInformation stickyInformation = new StickyInformation("eis/myPool", UUID.randomUUID())
+        TransactionPoolMapper.getInstance().setStickyInformationForCurrentTransaction(stickyInformation)
 
         when:
-        TransactionPoolMapper.getInstance().setPoolNameForCurrentTransaction("eis/whateverPool")
+        TransactionPoolMapper.getInstance().setStickyInformationForCurrentTransaction(new StickyInformation("eis/whateverPool", UUID.randomUUID()))
 
         then:
         def e = thrown(CasualRuntimeException)

--- a/casual/casual-caller/src/test/java/se/laz/casual/connection/caller/TransactionManagerImpl.java
+++ b/casual/casual-caller/src/test/java/se/laz/casual/connection/caller/TransactionManagerImpl.java
@@ -19,11 +19,6 @@ public class TransactionManagerImpl implements TransactionManager
 {
     private Transaction currentTransaction;
 
-    public Transaction getCurrentTransaction()
-    {
-        return currentTransaction;
-    }
-
     public void setCurrentTransaction(Transaction currentTransaction)
     {
         this.currentTransaction = currentTransaction;

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,9 +7,9 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '2.2.19'
+version = '2.2.20'
 
-def casual_jca_version = '2.2.32'
+def casual_jca_version = '2.2.34'
 def gson_version = '2.10.1'
 
 ext.libs = [


### PR DESCRIPTION
When sticky is being used, tp(a)calls in the same transaction will use the same execution.

This will help with traceability.