### PR TITLE
refactor: replaced java.util.logging.Logger with System.Logger

### DIFF
--- a/casual/casual-caller-http-client/src/main/java/se/laz/casual/http/HttpClient.java
+++ b/casual/casual-caller-http-client/src/main/java/se/laz/casual/http/HttpClient.java
@@ -19,13 +19,12 @@ import se.laz.casual.api.flags.ServiceReturnState;
 import java.io.Closeable;
 import java.net.URI;
 import java.util.Objects;
-import java.util.logging.Logger;
 
 import static jakarta.ws.rs.client.Entity.entity;
 
 public class HttpClient implements Closeable
 {
-    private static final Logger LOG = Logger.getLogger(HttpClient.class.getName());
+    private static final System.Logger LOG = System.getLogger(HttpClient.class.getName());
     private final Client client;
     public HttpClient()
     {
@@ -44,7 +43,7 @@ public class HttpClient implements Closeable
         Objects.requireNonNull(uri, "uri can not be null");
         Objects.requireNonNull(buffer, "buffer can not be null");
         MediaType mediaType = CasualBufferTypeConverter.convert(CasualBufferType.unmarshall(buffer.getType()));
-        LOG.finest(() -> "issuing http request to " + uri);
+        LOG.log(System.Logger.Level.TRACE,() -> "issuing http request to " + uri);
         Response response = client.target(uri).request(mediaType).post(entity(buffer.getBytes().get(0), mediaType));
         ErrorState errorState = ResponseStatusConverter.convert(response.getStatusInfo().toEnum());
         if (errorState != ErrorState.OK)

--- a/casual/casual-caller-http-client/src/main/java/se/laz/casual/http/HttpClient.java
+++ b/casual/casual-caller-http-client/src/main/java/se/laz/casual/http/HttpClient.java
@@ -20,6 +20,8 @@ import java.io.Closeable;
 import java.net.URI;
 import java.util.Objects;
 
+import static java.lang.System.Logger.Level.*;
+
 import static jakarta.ws.rs.client.Entity.entity;
 
 public class HttpClient implements Closeable
@@ -43,7 +45,7 @@ public class HttpClient implements Closeable
         Objects.requireNonNull(uri, "uri can not be null");
         Objects.requireNonNull(buffer, "buffer can not be null");
         MediaType mediaType = CasualBufferTypeConverter.convert(CasualBufferType.unmarshall(buffer.getType()));
-        LOG.log(System.Logger.Level.TRACE,() -> "issuing http request to " + uri);
+        LOG.log(DEBUG,() -> "issuing http request to " + uri);
         Response response = client.target(uri).request(mediaType).post(entity(buffer.getBytes().get(0), mediaType));
         ErrorState errorState = ResponseStatusConverter.convert(response.getStatusInfo().toEnum());
         if (errorState != ErrorState.OK)

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryEntry.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryEntry.java
@@ -11,12 +11,10 @@ import se.laz.casual.jca.CasualConnectionFactory;
 import jakarta.resource.ResourceException;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class ConnectionFactoryEntry
 {
-    private static final Logger LOG = Logger.getLogger(ConnectionFactoryEntry.class.getName());
+    private static final System.Logger LOG = System.getLogger(ConnectionFactoryEntry.class.getName());
     private final ConnectionFactoryProducer connectionFactoryProducer;
     private final AtomicBoolean needsDomainDiscovery = new AtomicBoolean(false);
 
@@ -60,7 +58,8 @@ public class ConnectionFactoryEntry
     public void invalidate()
     {
         valid = false;
-        LOG.finest(() -> "Invalidated CasualConnection with jndiName=" + connectionFactoryProducer.getJndiName());
+        LOG.log(System.Logger.Level.TRACE, () -> "Invalidated CasualConnection with jndiName=" + connectionFactoryProducer.getJndiName());
+
     }
 
     //Note: due to try with resources usage where we never use the resource
@@ -71,13 +70,13 @@ public class ConnectionFactoryEntry
         {
             // We just want to check that a connection could be established to check connectivity
             valid = true;
-            LOG.finest(() -> "Successfully validated CasualConnection with jndiName=" + connectionFactoryProducer.getJndiName());
+            LOG.log(System.Logger.Level.TRACE, () -> "Successfully validated CasualConnection with jndiName=" + connectionFactoryProducer.getJndiName());
         }
         catch (ResourceException e)
         {
             // Failure to connect during validation should automatically invalidate ConnectionFactoryEntry
             valid = false;
-            LOG.log(Level.WARNING, e, ()->"Failed validation of CasualConnection with jndiName=" + connectionFactoryProducer.getJndiName() + ", received error: " + e.getMessage());
+            LOG.log(System.Logger.Level.WARNING, ()->"Failed validation of CasualConnection with jndiName=" + connectionFactoryProducer.getJndiName() + ", received error: " + e.getMessage());
         }
     }
 

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryEntry.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryEntry.java
@@ -12,6 +12,8 @@ import jakarta.resource.ResourceException;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static java.lang.System.Logger.Level.*;
+
 public class ConnectionFactoryEntry
 {
     private static final System.Logger LOG = System.getLogger(ConnectionFactoryEntry.class.getName());
@@ -58,7 +60,7 @@ public class ConnectionFactoryEntry
     public void invalidate()
     {
         valid = false;
-        LOG.log(System.Logger.Level.TRACE, () -> "Invalidated CasualConnection with jndiName=" + connectionFactoryProducer.getJndiName());
+        LOG.log(DEBUG, () -> "Invalidated CasualConnection with jndiName=" + connectionFactoryProducer.getJndiName());
 
     }
 
@@ -70,13 +72,13 @@ public class ConnectionFactoryEntry
         {
             // We just want to check that a connection could be established to check connectivity
             valid = true;
-            LOG.log(System.Logger.Level.TRACE, () -> "Successfully validated CasualConnection with jndiName=" + connectionFactoryProducer.getJndiName());
+            LOG.log(DEBUG, () -> "Successfully validated CasualConnection with jndiName=" + connectionFactoryProducer.getJndiName());
         }
         catch (ResourceException e)
         {
             // Failure to connect during validation should automatically invalidate ConnectionFactoryEntry
             valid = false;
-            LOG.log(System.Logger.Level.WARNING, ()->"Failed validation of CasualConnection with jndiName=" + connectionFactoryProducer.getJndiName() + ", received error: " + e.getMessage());
+            LOG.log(WARNING,()->"Failed validation of CasualConnection with jndiName=" + connectionFactoryProducer.getJndiName() + ", received error: " + e.getMessage(),e);
         }
     }
 

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryEntryStore.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryEntryStore.java
@@ -18,6 +18,8 @@ import jakarta.inject.Inject;
 import java.util.Collections;
 import java.util.List;
 
+import static java.lang.System.Logger.Level.*;
+
 @ApplicationScoped
 public class ConnectionFactoryEntryStore implements ConnectionObserver
 {
@@ -48,7 +50,7 @@ public class ConnectionFactoryEntryStore implements ConnectionObserver
             initialize();
             if(connectionFactories.isEmpty())
             {
-                LOG.log(System.Logger.Level.WARNING,()->"could not find any connection factories, casual-caller will not work. Will retry on next access.\n Either your configuration is wrong or the entries do not yet exist in the JNDI-tree just yet.");
+                LOG.log(WARNING,()->"could not find any connection factories, casual-caller will not work. Will retry on next access.\n Either your configuration is wrong or the entries do not yet exist in the JNDI-tree just yet.");
             }
         }
         return Collections.unmodifiableList(connectionFactories);

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryEntryStore.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionFactoryEntryStore.java
@@ -17,12 +17,11 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Logger;
 
 @ApplicationScoped
 public class ConnectionFactoryEntryStore implements ConnectionObserver
 {
-    private static final Logger LOG = Logger.getLogger(ConnectionFactoryEntryStore.class.getName());
+    private static final System.Logger LOG = System.getLogger(ConnectionFactoryEntryStore.class.getName());
     private final ConnectionFactoryFinder connectionFactoryFinder;
     private final TopologyChangedHandler topologyChangedHandler;
     private List<ConnectionFactoryEntry> connectionFactories;
@@ -49,7 +48,7 @@ public class ConnectionFactoryEntryStore implements ConnectionObserver
             initialize();
             if(connectionFactories.isEmpty())
             {
-                LOG.warning(() -> "could not find any connection factories, casual-caller will not work. Will retry on next access.\n Either your configuration is wrong or the entries do not yet exist in the JNDI-tree just yet.");
+                LOG.log(System.Logger.Level.WARNING,()->"could not find any connection factories, casual-caller will not work. Will retry on next access.\n Either your configuration is wrong or the entries do not yet exist in the JNDI-tree just yet.");
             }
         }
         return Collections.unmodifiableList(connectionFactories);

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionValidator.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionValidator.java
@@ -8,7 +8,7 @@ package se.laz.casual.connection.caller;
 
 import jakarta.inject.Inject;
 
-import java.util.logging.Level;
+import static java.lang.System.Logger.Level.*;
 
 public class ConnectionValidator
 {
@@ -38,7 +38,7 @@ public class ConnectionValidator
                                        catch(Exception e)
                                        {
                                            connectionFactoryEntry.invalidate();
-                                           LOG.log(System.Logger.Level.WARNING, () -> "Failed validating: " + connectionFactoryEntry);
+                                           LOG.log(WARNING, () -> "Failed validating: " + connectionFactoryEntry,e);
                                        }
                                    });
     }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionValidator.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/ConnectionValidator.java
@@ -9,11 +9,10 @@ package se.laz.casual.connection.caller;
 import jakarta.inject.Inject;
 
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class ConnectionValidator
 {
-    private static final Logger LOG = Logger.getLogger(ConnectionValidator.class.getName());
+    private static final System.Logger LOG = System.getLogger(ConnectionValidator.class.getName());
     private CacheRepopulator repopulator;
     private ConnectionFactoryEntryStore connectionFactoryEntryStore;
 
@@ -39,7 +38,7 @@ public class ConnectionValidator
                                        catch(Exception e)
                                        {
                                            connectionFactoryEntry.invalidate();
-                                           LOG.log(Level.WARNING, e, () -> "Failed validating: " + connectionFactoryEntry);
+                                           LOG.log(System.Logger.Level.WARNING, () -> "Failed validating: " + connectionFactoryEntry);
                                        }
                                    });
     }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/DomainIdChecker.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/DomainIdChecker.java
@@ -8,6 +8,7 @@ package se.laz.casual.connection.caller;
 import se.laz.casual.jca.CasualConnection;
 import se.laz.casual.jca.DomainId;
 
+import static java.lang.System.Logger.Level.*;
 
 public class DomainIdChecker
 {
@@ -26,7 +27,7 @@ public class DomainIdChecker
         }
         catch(Exception e)
         {
-            LOG.log(System.Logger.Level.WARNING, () -> "failed comparing domain id: " + domainId + " - most likely the connection is gone");
+            LOG.log(WARNING, () -> "failed comparing domain id: " + domainId + " - most likely the connection is gone",e);
         }
         return false;
     }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/DomainIdChecker.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/DomainIdChecker.java
@@ -8,12 +8,10 @@ package se.laz.casual.connection.caller;
 import se.laz.casual.jca.CasualConnection;
 import se.laz.casual.jca.DomainId;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class DomainIdChecker
 {
-    private static final Logger LOG = Logger.getLogger(DomainIdChecker.class.getName());
+    private static final System.Logger LOG = System.getLogger(DomainIdChecker.class.getName());
     private DomainIdChecker()
     {}
 
@@ -28,7 +26,7 @@ public class DomainIdChecker
         }
         catch(Exception e)
         {
-            LOG.log(Level.WARNING, e, () -> "failed comparing domain id: " + domainId + " - most likely the connection is gone");
+            LOG.log(System.Logger.Level.WARNING, () -> "failed comparing domain id: " + domainId + " - most likely the connection is gone");
         }
         return false;
     }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/FailoverAlgorithm.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/FailoverAlgorithm.java
@@ -25,6 +25,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static java.lang.System.Logger.Level.*;
+
 public class FailoverAlgorithm
 {
     private static final System.Logger LOG = System.getLogger(FailoverAlgorithm.class.getName());
@@ -40,7 +42,7 @@ public class FailoverAlgorithm
         // No valid casual server found (revalidation is on a timer in ConnectionFactoryEntryValidationTimer)
         if (validEntries.isEmpty())
         {
-            LOG.log(System.Logger.Level.WARNING,() -> ALL_FAIL_MESSAGE + serviceName);
+            LOG.log(WARNING,() -> ALL_FAIL_MESSAGE + serviceName);
             return doTpenoent.get();
         }
         ServiceReturn<CasualBuffer> result = issueCall(serviceName, validEntries, doCall);
@@ -54,7 +56,7 @@ public class FailoverAlgorithm
             // No valid casual server found (revalidation is on a timer in ConnectionFactoryEntryValidationTimer)
             if (validEntries.isEmpty())
             {
-                LOG.log(System.Logger.Level.WARNING,() -> ALL_FAIL_MESSAGE + serviceName);
+                LOG.log(WARNING,() -> ALL_FAIL_MESSAGE + serviceName);
                 return doTpenoent.get();
             }
             result = issueCall(serviceName, validEntries, doCall);
@@ -72,7 +74,7 @@ public class FailoverAlgorithm
         // No valid casual server found (revalidation is on a timer in ConnectionFactoryEntryValidationTimer)
         if (validEntries.isEmpty())
         {
-            LOG.log(System.Logger.Level.WARNING,() -> ALL_FAIL_MESSAGE + serviceName);
+            LOG.log(WARNING,() -> ALL_FAIL_MESSAGE + serviceName);
             return doTpenoent.get();
         }
         return issueCall(serviceName, validEntries, doCall);
@@ -87,7 +89,7 @@ public class FailoverAlgorithm
         // No valid casual server found (revalidation is on a timer in ConnectionFactoryEntryValidationTimer)
         if (validEntries.isEmpty())
         {
-            LOG.log(System.Logger.Level.WARNING,() -> ALL_FAIL_MESSAGE + serviceName);
+            LOG.log(WARNING,() -> ALL_FAIL_MESSAGE + serviceName);
             return doTpenoent.get();
         }
         return ConversationFailover.tpconnectWithFailover(serviceName, validEntries, doCall);
@@ -100,7 +102,7 @@ public class FailoverAlgorithm
         // This is always through the cache, either it was already there or a lookup was issued and then stored
         List<ConnectionFactoryEntry> prioritySortedFactories = lookup.get(serviceName);
         List<ConnectionFactoryEntry> validEntries = prioritySortedFactories.stream().filter(ConnectionFactoryEntry::isValid).collect(Collectors.toList());
-        LOG.log(System.Logger.Level.TRACE,() -> "Entries found for '" + serviceName + "' with " + validEntries.size() + " of " + prioritySortedFactories.size() + " possible connection factories");
+        LOG.log(DEBUG,() -> "Entries found for '" + serviceName + "' with " + validEntries.size() + " of " + prioritySortedFactories.size() + " possible connection factories");
         return validEntries;
     }
 
@@ -120,7 +122,7 @@ public class FailoverAlgorithm
         }
         catch (ResourceException | DomainDisconnectedException e)
         {
-            LOG.log(System.Logger.Level.TRACE,"Failed call for stickied pool with exception, will run failover if applicable");
+            LOG.log(DEBUG,"Failed call for stickied pool with exception, will run failover if applicable");
             thrownException = e;
         }
 

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/FailoverAlgorithm.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/FailoverAlgorithm.java
@@ -23,12 +23,11 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 public class FailoverAlgorithm
 {
-    private static final Logger LOG = Logger.getLogger(FailoverAlgorithm.class.getName());
+    private static final System.Logger LOG = System.getLogger(FailoverAlgorithm.class.getName());
     private static final String ALL_FAIL_MESSAGE = "Received a set of ConnectionFactoryEntries, but not one was valid for service ";
 
     public ServiceReturn<CasualBuffer> tpcallWithFailover(
@@ -41,7 +40,7 @@ public class FailoverAlgorithm
         // No valid casual server found (revalidation is on a timer in ConnectionFactoryEntryValidationTimer)
         if (validEntries.isEmpty())
         {
-            LOG.warning(() -> ALL_FAIL_MESSAGE + serviceName);
+            LOG.log(System.Logger.Level.WARNING,() -> ALL_FAIL_MESSAGE + serviceName);
             return doTpenoent.get();
         }
         ServiceReturn<CasualBuffer> result = issueCall(serviceName, validEntries, doCall);
@@ -55,7 +54,7 @@ public class FailoverAlgorithm
             // No valid casual server found (revalidation is on a timer in ConnectionFactoryEntryValidationTimer)
             if (validEntries.isEmpty())
             {
-                LOG.warning(() -> ALL_FAIL_MESSAGE + serviceName);
+                LOG.log(System.Logger.Level.WARNING,() -> ALL_FAIL_MESSAGE + serviceName);
                 return doTpenoent.get();
             }
             result = issueCall(serviceName, validEntries, doCall);
@@ -73,7 +72,7 @@ public class FailoverAlgorithm
         // No valid casual server found (revalidation is on a timer in ConnectionFactoryEntryValidationTimer)
         if (validEntries.isEmpty())
         {
-            LOG.warning(() -> ALL_FAIL_MESSAGE + serviceName);
+            LOG.log(System.Logger.Level.WARNING,() -> ALL_FAIL_MESSAGE + serviceName);
             return doTpenoent.get();
         }
         return issueCall(serviceName, validEntries, doCall);
@@ -88,7 +87,7 @@ public class FailoverAlgorithm
         // No valid casual server found (revalidation is on a timer in ConnectionFactoryEntryValidationTimer)
         if (validEntries.isEmpty())
         {
-            LOG.warning(() -> ALL_FAIL_MESSAGE + serviceName);
+            LOG.log(System.Logger.Level.WARNING,() -> ALL_FAIL_MESSAGE + serviceName);
             return doTpenoent.get();
         }
         return ConversationFailover.tpconnectWithFailover(serviceName, validEntries, doCall);
@@ -101,7 +100,7 @@ public class FailoverAlgorithm
         // This is always through the cache, either it was already there or a lookup was issued and then stored
         List<ConnectionFactoryEntry> prioritySortedFactories = lookup.get(serviceName);
         List<ConnectionFactoryEntry> validEntries = prioritySortedFactories.stream().filter(ConnectionFactoryEntry::isValid).collect(Collectors.toList());
-        LOG.finest(() -> "Entries found for '" + serviceName + "' with " + validEntries.size() + " of " + prioritySortedFactories.size() + " possible connection factories");
+        LOG.log(System.Logger.Level.TRACE,() -> "Entries found for '" + serviceName + "' with " + validEntries.size() + " of " + prioritySortedFactories.size() + " possible connection factories");
         return validEntries;
     }
 
@@ -121,7 +120,7 @@ public class FailoverAlgorithm
         }
         catch (ResourceException | DomainDisconnectedException e)
         {
-            LOG.finest("Failed call for stickied pool with exception, will run failover if applicable");
+            LOG.log(System.Logger.Level.TRACE,"Failed call for stickied pool with exception, will run failover if applicable");
             thrownException = e;
         }
 

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/Lookup.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/Lookup.java
@@ -14,12 +14,10 @@ import jakarta.resource.ResourceException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class Lookup
 {
-    private static final Logger LOG = Logger.getLogger(Lookup.class.getName());
+    private static final System.Logger LOG = System.getLogger(Lookup.class.getName());
 
     public List<ConnectionFactoryEntry> find(QueueInfo qinfo, List<ConnectionFactoryEntry> cacheEntries, TransactionLess transactionLess)
     {
@@ -46,7 +44,7 @@ public class Lookup
                 }
                 catch (ResourceException e)
                 {
-                   LOG.log(Level.WARNING, e, ()->"Skipping connection factory " + entry.getJndiName() + " for service lookup, received error: " + e.getMessage());
+                   LOG.log(System.Logger.Level.WARNING, ()->"Skipping connection factory " + entry.getJndiName() + " for service lookup, received error: " + e.getMessage());
                 }
             }
         }
@@ -67,7 +65,7 @@ public class Lookup
             }
             catch (ResourceException e)
             {
-                LOG.log(Level.WARNING, e, ()->"Skipping connection factory " + entry.getJndiName() + " for queue lookup on, received error: " + e.getMessage());
+                LOG.log(System.Logger.Level.WARNING, ()->"Skipping connection factory " + entry.getJndiName() + " for queue lookup on, received error: " + e.getMessage());
             }
         }
         return foundEntries;

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/Lookup.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/Lookup.java
@@ -15,6 +15,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
+import static java.lang.System.Logger.Level.*;
+
 public class Lookup
 {
     private static final System.Logger LOG = System.getLogger(Lookup.class.getName());
@@ -44,7 +46,7 @@ public class Lookup
                 }
                 catch (ResourceException e)
                 {
-                   LOG.log(System.Logger.Level.WARNING, ()->"Skipping connection factory " + entry.getJndiName() + " for service lookup, received error: " + e.getMessage());
+                   LOG.log(WARNING, ()->"Skipping connection factory " + entry.getJndiName() + " for service lookup, received error: " + e.getMessage(),e);
                 }
             }
         }
@@ -65,7 +67,7 @@ public class Lookup
             }
             catch (ResourceException e)
             {
-                LOG.log(System.Logger.Level.WARNING, ()->"Skipping connection factory " + entry.getJndiName() + " for queue lookup on, received error: " + e.getMessage());
+                LOG.log(WARNING, ()->"Skipping connection factory " + entry.getJndiName() + " for queue lookup on, received error: " + e.getMessage(),e);
             }
         }
         return foundEntries;

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/QueueCache.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/QueueCache.java
@@ -15,6 +15,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static java.lang.System.Logger.Level.*;
+
 public class QueueCache
 {
     private static final System.Logger LOG = System.getLogger(QueueCache.class.getName());
@@ -55,7 +57,7 @@ public class QueueCache
 
                 if(cachedForQueue.isEmpty())
                 {
-                    LOG.log(System.Logger.Level.INFO,() -> "No valid connection for queuename: " + queueName);
+                    LOG.log(INFO,() -> "No valid connection for queuename: " + queueName);
                     return Optional.empty();
                 }
 
@@ -64,7 +66,7 @@ public class QueueCache
                 stickies.put(queueName, selectedFactory);
 
                 if (cachedForQueue.size() > 1) {
-                    LOG.log(System.Logger.Level.INFO,() -> "Found multiple (" + cachedForQueue.size() + ") sources for queue '" + queueName
+                    LOG.log(INFO,() -> "Found multiple (" + cachedForQueue.size() + ") sources for queue '" + queueName
                             + "', selecting and setting sticky for CasualConnectionFactory=" + selectedFactory);
                 }
 

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/QueueCache.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/QueueCache.java
@@ -14,11 +14,10 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Logger;
 
 public class QueueCache
 {
-    private static final Logger LOG = Logger.getLogger(QueueCache.class.getName());
+    private static final System.Logger LOG = System.getLogger(QueueCache.class.getName());
 
     private final Map<String, List<ConnectionFactoryEntry>> cacheMap = new ConcurrentHashMap<>();
     private final Map<String, ConnectionFactoryEntry> stickies = new ConcurrentHashMap<>();
@@ -56,7 +55,7 @@ public class QueueCache
 
                 if(cachedForQueue.isEmpty())
                 {
-                    LOG.info(() -> "No valid connection for queuename: " + queueName);
+                    LOG.log(System.Logger.Level.INFO,() -> "No valid connection for queuename: " + queueName);
                     return Optional.empty();
                 }
 
@@ -65,7 +64,7 @@ public class QueueCache
                 stickies.put(queueName, selectedFactory);
 
                 if (cachedForQueue.size() > 1) {
-                    LOG.info(() -> "Found multiple (" + cachedForQueue.size() + ") sources for queue '" + queueName
+                    LOG.log(System.Logger.Level.INFO,() -> "Found multiple (" + cachedForQueue.size() + ") sources for queue '" + queueName
                             + "', selecting and setting sticky for CasualConnectionFactory=" + selectedFactory);
                 }
 

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/StickyTransactionHandler.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/StickyTransactionHandler.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import se.laz.casual.connection.caller.functions.BiFunctionThrowsResourceException;
@@ -20,7 +19,7 @@ import se.laz.casual.network.connection.CasualConnectionException;
 
 public class StickyTransactionHandler
 {
-    private static final Logger LOG = Logger.getLogger(StickyTransactionHandler.class.getName());
+    private static final System.Logger LOG = System.getLogger(StickyTransactionHandler.class.getName());
 
     private StickyTransactionHandler()
     {}
@@ -51,7 +50,7 @@ public class StickyTransactionHandler
             // We have a specific stickied pool to use that looks usable, try to use it
             StickiedCallInfo sticky = stickyMaybe.get();
             factories.remove(sticky.connectionFactoryEntry()); // If we later need to do failover stuff we don't want to retry with this one
-            LOG.finest(() -> "Attempting to use pool=" + sticky.connectionFactoryEntry().getJndiName() + " with sticky to current transaction.");
+            LOG.log(System.Logger.Level.TRACE,() -> "Attempting to use pool=" + sticky.connectionFactoryEntry().getJndiName() + " with sticky to current transaction.");
             try (CasualConnection con = sticky.connectionFactoryEntry().getConnectionFactory().getConnection())
             {
                 return Optional.of(doCall.apply(con, sticky.execution()));
@@ -69,7 +68,7 @@ public class StickyTransactionHandler
         }
         else
         {
-            LOG.finest(() -> "Current sticky is " + transactionPoolMapperSupplier.get().getStickyInformationForCurrentTransaction()
+            LOG.log(System.Logger.Level.TRACE,() -> "Current sticky is " + transactionPoolMapperSupplier.get().getStickyInformationForCurrentTransaction()
                     + " but called service=" + serviceName
                     + " is currently available in pools [" + factories.stream().map(ConnectionFactoryEntry::getJndiName).collect(Collectors.joining(","))
                     + "]. Will use available pools instead of stickied pool.");
@@ -87,7 +86,7 @@ public class StickyTransactionHandler
             ConnectionFactoryEntry newStickyFactory = validFactories.get(0);
             StickyInformation newStickyInformation = new StickyInformation(newStickyFactory.getJndiName(), UUID.randomUUID());
             transactionPoolMapperSupplier.get().setStickyInformationForCurrentTransaction(newStickyInformation);
-            LOG.finest(() -> "No sticky present for call to service=" + serviceName + ", setting sticky=" + newStickyFactory.getJndiName() + " with=" + newStickyInformation);
+            LOG.log(System.Logger.Level.TRACE,() -> "No sticky present for call to service=" + serviceName + ", setting sticky=" + newStickyFactory.getJndiName() + " with=" + newStickyInformation);
             return Optional.of(new StickiedCallInfo(newStickyFactory, newStickyInformation.execution()));
         }
         else
@@ -99,14 +98,14 @@ public class StickyTransactionHandler
 
             if (stickyMatch.isPresent())
             {
-                LOG.finest(() -> "Using stickied pool=" + stickyInformation + " for call to service=" + serviceName);
+                LOG.log(System.Logger.Level.TRACE,() -> "Using stickied pool=" + stickyInformation + " for call to service=" + serviceName);
                 ConnectionFactoryEntry stickyEntry = stickyMatch.get();
                 validFactories.remove(stickyEntry);
                 return Optional.of(new StickiedCallInfo(stickyEntry, stickyInformation.execution()));
             }
             else
             {
-                LOG.finest(() -> "There was a sticky=" + stickyInformation + ", but it did not match the valid factories for the called service=" + serviceName);
+                LOG.log(System.Logger.Level.TRACE,() -> "There was a sticky=" + stickyInformation + ", but it did not match the valid factories for the called service=" + serviceName);
                 return Optional.empty();
             }
         }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/StickyTransactionHandler.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/StickyTransactionHandler.java
@@ -17,6 +17,8 @@ import java.util.stream.Collectors;
 import se.laz.casual.connection.caller.functions.BiFunctionThrowsResourceException;
 import se.laz.casual.network.connection.CasualConnectionException;
 
+import static java.lang.System.Logger.Level.*;
+
 public class StickyTransactionHandler
 {
     private static final System.Logger LOG = System.getLogger(StickyTransactionHandler.class.getName());
@@ -50,7 +52,7 @@ public class StickyTransactionHandler
             // We have a specific stickied pool to use that looks usable, try to use it
             StickiedCallInfo sticky = stickyMaybe.get();
             factories.remove(sticky.connectionFactoryEntry()); // If we later need to do failover stuff we don't want to retry with this one
-            LOG.log(System.Logger.Level.TRACE,() -> "Attempting to use pool=" + sticky.connectionFactoryEntry().getJndiName() + " with sticky to current transaction.");
+            LOG.log(DEBUG,() -> "Attempting to use pool=" + sticky.connectionFactoryEntry().getJndiName() + " with sticky to current transaction.");
             try (CasualConnection con = sticky.connectionFactoryEntry().getConnectionFactory().getConnection())
             {
                 return Optional.of(doCall.apply(con, sticky.execution()));
@@ -68,7 +70,7 @@ public class StickyTransactionHandler
         }
         else
         {
-            LOG.log(System.Logger.Level.TRACE,() -> "Current sticky is " + transactionPoolMapperSupplier.get().getStickyInformationForCurrentTransaction()
+            LOG.log(DEBUG,() -> "Current sticky is " + transactionPoolMapperSupplier.get().getStickyInformationForCurrentTransaction()
                     + " but called service=" + serviceName
                     + " is currently available in pools [" + factories.stream().map(ConnectionFactoryEntry::getJndiName).collect(Collectors.joining(","))
                     + "]. Will use available pools instead of stickied pool.");
@@ -86,7 +88,7 @@ public class StickyTransactionHandler
             ConnectionFactoryEntry newStickyFactory = validFactories.get(0);
             StickyInformation newStickyInformation = new StickyInformation(newStickyFactory.getJndiName(), UUID.randomUUID());
             transactionPoolMapperSupplier.get().setStickyInformationForCurrentTransaction(newStickyInformation);
-            LOG.log(System.Logger.Level.TRACE,() -> "No sticky present for call to service=" + serviceName + ", setting sticky=" + newStickyFactory.getJndiName() + " with=" + newStickyInformation);
+            LOG.log(DEBUG,() -> "No sticky present for call to service=" + serviceName + ", setting sticky=" + newStickyFactory.getJndiName() + " with=" + newStickyInformation);
             return Optional.of(new StickiedCallInfo(newStickyFactory, newStickyInformation.execution()));
         }
         else
@@ -98,14 +100,14 @@ public class StickyTransactionHandler
 
             if (stickyMatch.isPresent())
             {
-                LOG.log(System.Logger.Level.TRACE,() -> "Using stickied pool=" + stickyInformation + " for call to service=" + serviceName);
+                LOG.log(DEBUG,() -> "Using stickied pool=" + stickyInformation + " for call to service=" + serviceName);
                 ConnectionFactoryEntry stickyEntry = stickyMatch.get();
                 validFactories.remove(stickyEntry);
                 return Optional.of(new StickiedCallInfo(stickyEntry, stickyInformation.execution()));
             }
             else
             {
-                LOG.log(System.Logger.Level.TRACE,() -> "There was a sticky=" + stickyInformation + ", but it did not match the valid factories for the called service=" + serviceName);
+                LOG.log(DEBUG,() -> "There was a sticky=" + stickyInformation + ", but it did not match the valid factories for the called service=" + serviceName);
                 return Optional.empty();
             }
         }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/TransactionLess.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/TransactionLess.java
@@ -22,11 +22,10 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.logging.Logger;
 
 public class TransactionLess
 {
-    private static final Logger LOG = Logger.getLogger(TransactionLess.class.getName());
+    private static final System.Logger LOG = System.getLogger(TransactionLess.class.getName());
     @Transactional(Transactional.TxType.NOT_SUPPORTED)
     public ServiceReturn<CasualBuffer> tpcall(Supplier<ServiceReturn<CasualBuffer>> supplier)
     {
@@ -62,8 +61,8 @@ public class TransactionLess
     {
        try(CasualConnection connection = connectionFactoryEntry.getConnectionFactory().getConnection())
        {
-          LOG.finest(() -> "domain discovery for all known services/queues will be issued for " + connectionFactoryEntry );
-          LOG.finest(() -> "all known services/queues being, services: " + cachedItems.get(CacheType.SERVICE) + " queues: " + cachedItems.get(CacheType.QUEUE));
+          LOG.log(System.Logger.Level.TRACE,() -> "domain discovery for all known services/queues will be issued for " + connectionFactoryEntry );
+          LOG.log(System.Logger.Level.TRACE,() -> "all known services/queues being, services: " + cachedItems.get(CacheType.SERVICE) + " queues: " + cachedItems.get(CacheType.QUEUE));
           return Optional.of(connection.discover(UUID.randomUUID(),
                   cachedItems.get(CacheType.SERVICE),
                   cachedItems.get(CacheType.QUEUE)));
@@ -71,8 +70,8 @@ public class TransactionLess
        catch (ResourceException e)
        {
           connectionFactoryEntry.invalidate();
-          LOG.warning(() -> "failed domain discovery for: " + connectionFactoryEntry + " -> " + e);
-          LOG.warning(() -> "services: " + cachedItems.get(CacheType.SERVICE) + " queues: " + cachedItems.get(CacheType.QUEUE));
+          LOG.log(System.Logger.Level.WARNING,() -> "failed domain discovery for: " + connectionFactoryEntry + " -> " + e);
+          LOG.log(System.Logger.Level.WARNING,() -> "services: " + cachedItems.get(CacheType.SERVICE) + " queues: " + cachedItems.get(CacheType.QUEUE));
        }
        return Optional.empty();
     }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/TransactionLess.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/TransactionLess.java
@@ -23,6 +23,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static java.lang.System.Logger.Level.*;
+
 public class TransactionLess
 {
     private static final System.Logger LOG = System.getLogger(TransactionLess.class.getName());
@@ -61,8 +63,8 @@ public class TransactionLess
     {
        try(CasualConnection connection = connectionFactoryEntry.getConnectionFactory().getConnection())
        {
-          LOG.log(System.Logger.Level.TRACE,() -> "domain discovery for all known services/queues will be issued for " + connectionFactoryEntry );
-          LOG.log(System.Logger.Level.TRACE,() -> "all known services/queues being, services: " + cachedItems.get(CacheType.SERVICE) + " queues: " + cachedItems.get(CacheType.QUEUE));
+          LOG.log(DEBUG,() -> "domain discovery for all known services/queues will be issued for " + connectionFactoryEntry );
+          LOG.log(DEBUG,() -> "all known services/queues being, services: " + cachedItems.get(CacheType.SERVICE) + " queues: " + cachedItems.get(CacheType.QUEUE));
           return Optional.of(connection.discover(UUID.randomUUID(),
                   cachedItems.get(CacheType.SERVICE),
                   cachedItems.get(CacheType.QUEUE)));
@@ -70,8 +72,8 @@ public class TransactionLess
        catch (ResourceException e)
        {
           connectionFactoryEntry.invalidate();
-          LOG.log(System.Logger.Level.WARNING,() -> "failed domain discovery for: " + connectionFactoryEntry + " -> " + e);
-          LOG.log(System.Logger.Level.WARNING,() -> "services: " + cachedItems.get(CacheType.SERVICE) + " queues: " + cachedItems.get(CacheType.QUEUE));
+          LOG.log(WARNING,() -> "failed domain discovery for: " + connectionFactoryEntry + " -> " + e,e);
+          LOG.log(WARNING,() -> "services: " + cachedItems.get(CacheType.SERVICE) + " queues: " + cachedItems.get(CacheType.QUEUE),e);
        }
        return Optional.empty();
     }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/TransactionPoolMapper.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/TransactionPoolMapper.java
@@ -22,6 +22,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static java.lang.System.Logger.Level.*;
+
 public class TransactionPoolMapper
 {
     private static final System.Logger LOG = System.getLogger(TransactionPoolMapper.class.getName());
@@ -138,7 +140,7 @@ public class TransactionPoolMapper
             }
             catch (NamingException e)
             {
-                LOG.log(System.Logger.Level.ERROR,"Failed to load TransactionSynchronizationRegistry, will not be able to remove registered transaction pool mappings on completion.");
+                LOG.log(ERROR,"Failed to load TransactionSynchronizationRegistry, will not be able to remove registered transaction pool mappings on completion.");
             }
         }
 
@@ -191,7 +193,7 @@ public class TransactionPoolMapper
         }
         catch (SystemException e)
         {
-            LOG.log(System.Logger.Level.ERROR, "Failed to get transaction from TransactionManager, will report pool mapping disabled", e);
+            LOG.log(ERROR, "Failed to get transaction from TransactionManager, will report pool mapping disabled", e);
             return false;
         }
     }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/TransactionPoolMapper.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/TransactionPoolMapper.java
@@ -21,12 +21,10 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class TransactionPoolMapper
 {
-    private static final Logger LOG = Logger.getLogger(TransactionPoolMapper.class.getName());
+    private static final System.Logger LOG = System.getLogger(TransactionPoolMapper.class.getName());
     private final Map<Transaction, StickyInformation> transactionStickies = new ConcurrentHashMap<>();
 
     private boolean stickyEnabled = ConfigurationService.getInstance().getConfiguration().isTransactionStickyEnabled();
@@ -140,7 +138,7 @@ public class TransactionPoolMapper
             }
             catch (NamingException e)
             {
-                LOG.severe("Failed to load TransactionSynchronizationRegistry, will not be able to remove registered transaction pool mappings on completion.");
+                LOG.log(System.Logger.Level.ERROR,"Failed to load TransactionSynchronizationRegistry, will not be able to remove registered transaction pool mappings on completion.");
             }
         }
 
@@ -193,7 +191,7 @@ public class TransactionPoolMapper
         }
         catch (SystemException e)
         {
-            LOG.log(Level.SEVERE, "Failed to get transaction from TransactionManager, will report pool mapping disabled", e);
+            LOG.log(System.Logger.Level.ERROR, "Failed to get transaction from TransactionManager, will report pool mapping disabled", e);
             return false;
         }
     }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/jmx/JMXStartup.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/jmx/JMXStartup.java
@@ -23,13 +23,12 @@ import javax.management.MalformedObjectNameException;
 import javax.management.NotCompliantMBeanException;
 import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
-import java.util.logging.Logger;
 
 @Startup
 @Singleton
 public class JMXStartup
 {
-    private static final Logger LOG = Logger.getLogger(JMXStartup.class.getName());
+    private static final System.Logger LOG = System.getLogger(JMXStartup.class.getName());
     private static final String NAME = "se.laz.casual.caller:type=CasualCallerControl";
     private Cache cache;
     private ConnectionFactoryEntryStore connectionFactoryEntryStore;
@@ -49,7 +48,7 @@ public class JMXStartup
     @PostConstruct
     void initJmx()
     {
-        LOG.finest("JMXStartup::begin");
+        LOG.log(System.Logger.Level.TRACE,"JMXStartup::begin");
 
         try {
             MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
@@ -66,13 +65,13 @@ public class JMXStartup
             throw new CasualRuntimeException(e);
         }
 
-        LOG.finest("JMXStartup::end");
+        LOG.log(System.Logger.Level.TRACE,"JMXStartup::end");
     }
 
     @PreDestroy
     void tearDownJmx()
     {
-        LOG.finest("JMXTeardown::begin");
+        LOG.log(System.Logger.Level.TRACE,"JMXTeardown::begin");
 
         try {
             MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
@@ -86,7 +85,7 @@ public class JMXStartup
             throw new CasualRuntimeException(e);
         }
 
-        LOG.finest("JMXTeardown::end");
+        LOG.log(System.Logger.Level.TRACE,"JMXTeardown::end");
     }
 
     private void unregister(MBeanServer server, ObjectName name) throws MBeanRegistrationException

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/jmx/JMXStartup.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/jmx/JMXStartup.java
@@ -24,6 +24,8 @@ import javax.management.NotCompliantMBeanException;
 import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
 
+import static java.lang.System.Logger.Level.*;
+
 @Startup
 @Singleton
 public class JMXStartup
@@ -48,7 +50,7 @@ public class JMXStartup
     @PostConstruct
     void initJmx()
     {
-        LOG.log(System.Logger.Level.TRACE,"JMXStartup::begin");
+        LOG.log(DEBUG,"JMXStartup::begin");
 
         try {
             MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
@@ -65,13 +67,13 @@ public class JMXStartup
             throw new CasualRuntimeException(e);
         }
 
-        LOG.log(System.Logger.Level.TRACE,"JMXStartup::end");
+        LOG.log(DEBUG,"JMXStartup::end");
     }
 
     @PreDestroy
     void tearDownJmx()
     {
-        LOG.log(System.Logger.Level.TRACE,"JMXTeardown::begin");
+        LOG.log(DEBUG,"JMXTeardown::begin");
 
         try {
             MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
@@ -85,7 +87,7 @@ public class JMXStartup
             throw new CasualRuntimeException(e);
         }
 
-        LOG.log(System.Logger.Level.TRACE,"JMXTeardown::end");
+        LOG.log(DEBUG,"JMXTeardown::end");
     }
 
     private void unregister(MBeanServer server, ObjectName name) throws MBeanRegistrationException

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/topologychanged/TopologyChangedHandler.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/topologychanged/TopologyChangedHandler.java
@@ -23,6 +23,8 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import static java.lang.System.Logger.Level.*;
+
 @ApplicationScoped
 public class TopologyChangedHandler
 {
@@ -68,7 +70,7 @@ public class TopologyChangedHandler
     private void scheduleDiscovery(DomainId domainId)
     {
         long delayInMs = ConfigurationService.getInstance().getConfiguration().getTopologyChangeDelayMillis();
-        LOG.log(System.Logger.Level.TRACE,() -> "scheduling domain discovery for domain: " + domainId);
+        LOG.log(DEBUG,() -> "scheduling domain discovery for domain: " + domainId);
         try
         {
             DiscoveryTask task = new DiscoveryTask(domainId, connectionFactoryEntrySupplier, cacheRepopulator);
@@ -78,7 +80,7 @@ public class TopologyChangedHandler
         {
             changedDomains.remove(domainId);
             markForLaterDomainDiscovery(domainId);
-            LOG.log(System.Logger.Level.WARNING, () -> "Could not schedule task to handle topology change for domain: " + domainId + " it will be handled on the next tpcall/tpacall or enqueue/dequeue call");
+            LOG.log(WARNING, () -> "Could not schedule task to handle topology change for domain: " + domainId + " it will be handled on the next tpcall/tpacall or enqueue/dequeue call",e);
         }
     }
 
@@ -112,7 +114,7 @@ public class TopologyChangedHandler
             catch(Exception e)
             {
                 // catching since this method lives in a timer that should never ever throw
-                LOG.log(System.Logger.Level.WARNING, () -> "Failed handling topology update, most likely connection went away. Will be handled when connection is reestablished. Domain: " + domainId);
+                LOG.log(WARNING, () -> "Failed handling topology update, most likely connection went away. Will be handled when connection is reestablished. Domain: " + domainId,e);
             }
         }
         private void handleTopologyChanged(final DomainId domainId)
@@ -120,9 +122,9 @@ public class TopologyChangedHandler
             Optional<ConnectionFactoryEntry> maybeMatch = connectionFactoryEntrySupplier.get().stream()
                                                                                         .filter(connectionFactoryEntry -> DomainIdChecker.isSameDomain(domainId, connectionFactoryEntry))
                                                                                         .findFirst();
-            LOG.log(System.Logger.Level.TRACE,() -> "will issue domain discovery for domain: " + domainId);
+            LOG.log(DEBUG,() -> "will issue domain discovery for domain: " + domainId);
             maybeMatch.ifPresent(cacheRepopulator::repopulate);
-            LOG.log(System.Logger.Level.TRACE,() -> "domain discovery finished for domain: " + domainId);
+            LOG.log(DEBUG,() -> "domain discovery finished for domain: " + domainId);
             // if no match, then that connection is gone and the cache will be repopulated once it re-establishes a connection
             TopologyChangedDoneHandler.execute(TopologyChangedDoneData.createBuilder()
                                                                       .withWasUpdatedDuringDiscovery(updateRequestDuringDiscovery::contains)

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/topologychanged/TopologyChangedHandler.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/topologychanged/TopologyChangedHandler.java
@@ -22,13 +22,11 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 @ApplicationScoped
 public class TopologyChangedHandler
 {
-    private static final Logger LOG = Logger.getLogger(TopologyChangedHandler.class.getName());
+    private static final System.Logger LOG = System.getLogger(TopologyChangedHandler.class.getName());
     @Resource
     private ManagedScheduledExecutorService scheduledExecutorService;
     private final Set<DomainId> changedDomains = ConcurrentHashMap.newKeySet();
@@ -70,7 +68,7 @@ public class TopologyChangedHandler
     private void scheduleDiscovery(DomainId domainId)
     {
         long delayInMs = ConfigurationService.getInstance().getConfiguration().getTopologyChangeDelayMillis();
-        LOG.finest(() -> "scheduling domain discovery for domain: " + domainId);
+        LOG.log(System.Logger.Level.TRACE,() -> "scheduling domain discovery for domain: " + domainId);
         try
         {
             DiscoveryTask task = new DiscoveryTask(domainId, connectionFactoryEntrySupplier, cacheRepopulator);
@@ -80,7 +78,7 @@ public class TopologyChangedHandler
         {
             changedDomains.remove(domainId);
             markForLaterDomainDiscovery(domainId);
-            LOG.log(Level.WARNING, e, () -> "Could not schedule task to handle topology change for domain: " + domainId + " it will be handled on the next tpcall/tpacall or enqueue/dequeue call");
+            LOG.log(System.Logger.Level.WARNING, () -> "Could not schedule task to handle topology change for domain: " + domainId + " it will be handled on the next tpcall/tpacall or enqueue/dequeue call");
         }
     }
 
@@ -114,7 +112,7 @@ public class TopologyChangedHandler
             catch(Exception e)
             {
                 // catching since this method lives in a timer that should never ever throw
-                LOG.log(Level.WARNING, e, () -> "Failed handling topology update, most likely connection went away. Will be handled when connection is reestablished. Domain: " + domainId);
+                LOG.log(System.Logger.Level.WARNING, () -> "Failed handling topology update, most likely connection went away. Will be handled when connection is reestablished. Domain: " + domainId);
             }
         }
         private void handleTopologyChanged(final DomainId domainId)
@@ -122,9 +120,9 @@ public class TopologyChangedHandler
             Optional<ConnectionFactoryEntry> maybeMatch = connectionFactoryEntrySupplier.get().stream()
                                                                                         .filter(connectionFactoryEntry -> DomainIdChecker.isSameDomain(domainId, connectionFactoryEntry))
                                                                                         .findFirst();
-            LOG.finest(() -> "will issue domain discovery for domain: " + domainId);
+            LOG.log(System.Logger.Level.TRACE,() -> "will issue domain discovery for domain: " + domainId);
             maybeMatch.ifPresent(cacheRepopulator::repopulate);
-            LOG.finest(() -> "domain discovery finished for domain: " + domainId);
+            LOG.log(System.Logger.Level.TRACE,() -> "domain discovery finished for domain: " + domainId);
             // if no match, then that connection is gone and the cache will be repopulated once it re-establishes a connection
             TopologyChangedDoneHandler.execute(TopologyChangedDoneData.createBuilder()
                                                                       .withWasUpdatedDuringDiscovery(updateRequestDuringDiscovery::contains)

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/util/ConnectionFactoryFinder.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/util/ConnectionFactoryFinder.java
@@ -17,6 +17,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static java.lang.System.Logger.Level.*;
+
 public class ConnectionFactoryFinder
 {
     private static final System.Logger LOG = System.getLogger(ConnectionFactoryFinder.class.getName());
@@ -39,7 +41,7 @@ public class ConnectionFactoryFinder
         }
         catch (NamingException e)
         {
-            LOG.log(System.Logger.Level.WARNING,() -> "CasualConnectionFactory lookup failed, using CasualCaller will not work\n\n" + e);
+            LOG.log(WARNING,() -> "CasualConnectionFactory lookup failed, using CasualCaller will not work\n\n" + e,e);
         }
         return Collections.<ConnectionFactoryEntry>emptyList();
     }
@@ -58,14 +60,14 @@ public class ConnectionFactoryFinder
                 if(instance instanceof CasualConnectionFactory)
                 {
                     foundEntries.add(ConnectionFactoryEntry.of(ConnectionFactoryProducer.of(jndiName)));
-                    LOG.log(System.Logger.Level.INFO,() -> "found casual connection factory with JNDI-name: " + jndiName);
+                    LOG.log(INFO,() -> "found casual connection factory with JNDI-name: " + jndiName);
                 }
             }
             return foundEntries;
         }
         catch (NamingException e)
         {
-            LOG.log(System.Logger.Level.WARNING,() -> "CasualConnectionFactory lookup failed, using CasualCaller will not work\n\n" + e);
+            LOG.log(WARNING,() -> "CasualConnectionFactory lookup failed, using CasualCaller will not work\n\n" + e,e);
         }
         return Collections.<ConnectionFactoryEntry>emptyList();
     }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/util/ConnectionFactoryFinder.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/util/ConnectionFactoryFinder.java
@@ -16,11 +16,10 @@ import javax.naming.NamingException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Logger;
 
 public class ConnectionFactoryFinder
 {
-    private static final Logger log = Logger.getLogger(ConnectionFactoryFinder.class.getName());
+    private static final System.Logger LOG = System.getLogger(ConnectionFactoryFinder.class.getName());
     public ConnectionFactoryFinder()
     {
         // public NOP-constructor needed for wls-only
@@ -40,7 +39,7 @@ public class ConnectionFactoryFinder
         }
         catch (NamingException e)
         {
-            log.warning(() -> "CasualConnectionFactory lookup failed, using CasualCaller will not work\n\n" + e);
+            LOG.log(System.Logger.Level.WARNING,() -> "CasualConnectionFactory lookup failed, using CasualCaller will not work\n\n" + e);
         }
         return Collections.<ConnectionFactoryEntry>emptyList();
     }
@@ -59,14 +58,14 @@ public class ConnectionFactoryFinder
                 if(instance instanceof CasualConnectionFactory)
                 {
                     foundEntries.add(ConnectionFactoryEntry.of(ConnectionFactoryProducer.of(jndiName)));
-                    log.info(() -> "found casual connection factory with JNDI-name: " + jndiName);
+                    LOG.log(System.Logger.Level.INFO,() -> "found casual connection factory with JNDI-name: " + jndiName);
                 }
             }
             return foundEntries;
         }
         catch (NamingException e)
         {
-            log.warning(() -> "CasualConnectionFactory lookup failed, using CasualCaller will not work\n\n" + e);
+            LOG.log(System.Logger.Level.WARNING,() -> "CasualConnectionFactory lookup failed, using CasualCaller will not work\n\n" + e);
         }
         return Collections.<ConnectionFactoryEntry>emptyList();
     }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/validation/ConnectionFactoryEntryValidationTimer.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/validation/ConnectionFactoryEntryValidationTimer.java
@@ -20,14 +20,12 @@ import jakarta.inject.Inject;
 import se.laz.casual.connection.caller.ConnectionValidator;
 import se.laz.casual.connection.caller.config.ConfigurationService;
 
-import java.util.logging.Logger;
-
 @Singleton
 @Startup
 @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
 public class ConnectionFactoryEntryValidationTimer
 {
-    private static final Logger LOG = Logger.getLogger(ConnectionFactoryEntryValidationTimer.class.getName());
+    private static final System.Logger LOG = System.getLogger(ConnectionFactoryEntryValidationTimer.class.getName());
 
     @Resource
     private TimerService timerService;
@@ -57,14 +55,14 @@ public class ConnectionFactoryEntryValidationTimer
     @Timeout
     public void validateConnectionFactories()
     {
-        LOG.finest("Running ConnectionFactoryEntryValidationTimer");
+        LOG.log(System.Logger.Level.TRACE,"Running ConnectionFactoryEntryValidationTimer");
         try
         {
             connectionValidator.validateAllConnections();
         }
         catch(Exception e)
         {
-            LOG.warning(() -> "failed validating connection factories: " + e);
+            LOG.log(System.Logger.Level.WARNING,() -> "failed validating connection factories: " + e);
         }
         finally
         {

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/validation/ConnectionFactoryEntryValidationTimer.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/validation/ConnectionFactoryEntryValidationTimer.java
@@ -20,6 +20,8 @@ import jakarta.inject.Inject;
 import se.laz.casual.connection.caller.ConnectionValidator;
 import se.laz.casual.connection.caller.config.ConfigurationService;
 
+import static java.lang.System.Logger.Level.*;
+
 @Singleton
 @Startup
 @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
@@ -55,14 +57,14 @@ public class ConnectionFactoryEntryValidationTimer
     @Timeout
     public void validateConnectionFactories()
     {
-        LOG.log(System.Logger.Level.TRACE,"Running ConnectionFactoryEntryValidationTimer");
+        LOG.log(DEBUG,"Running ConnectionFactoryEntryValidationTimer");
         try
         {
             connectionValidator.validateAllConnections();
         }
         catch(Exception e)
         {
-            LOG.log(System.Logger.Level.WARNING,() -> "failed validating connection factories: " + e);
+            LOG.log(WARNING,() -> "failed validating connection factories: " + e,e);
         }
         finally
         {

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '3.3.2'
+version = '3.3.3'
 
 def casual_jca_version = '3.3.0'
 def gson_version = '2.11.0'


### PR DESCRIPTION
This PR replaces all usages of java.util.logging.Logger with the more modern and flexible System.Logger API introduced in Java 9.

Ran ./gradlew test to verify no regression.
All tests pass successfully.

