### PR TITLE
feat: Added EJB for caller info

### DIFF
--- a/casual/casual-caller-api/src/main/java/se/laz/casual/connection/caller/info/CasualInfo.java
+++ b/casual/casual-caller-api/src/main/java/se/laz/casual/connection/caller/info/CasualInfo.java
@@ -1,0 +1,9 @@
+package se.laz.casual.connection.caller.info;
+
+import java.util.List;
+
+public interface CasualInfo
+{
+    List<Service> getServices();
+    void discoverService(String service);
+}

--- a/casual/casual-caller-api/src/main/java/se/laz/casual/connection/caller/info/CasualInfo.java
+++ b/casual/casual-caller-api/src/main/java/se/laz/casual/connection/caller/info/CasualInfo.java
@@ -1,9 +1,6 @@
 package se.laz.casual.connection.caller.info;
 
-import java.util.List;
-
 public interface CasualInfo
 {
-    List<Service> getServices();
     void discoverService(String service);
 }

--- a/casual/casual-caller-api/src/main/java/se/laz/casual/connection/caller/info/Service.java
+++ b/casual/casual-caller-api/src/main/java/se/laz/casual/connection/caller/info/Service.java
@@ -1,0 +1,95 @@
+package se.laz.casual.connection.caller.info;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Objects;
+
+public class Service implements Serializable
+{
+    @Serial
+    private static final long serialVersionUID = 7441523856061920556L;
+    private final String name;
+    private final long hops;
+    private final boolean valid;
+    private final String jndiName;
+
+    private Service(Builder builder)
+    {
+        this.name = builder.name;
+        this.hops = builder.hops;
+        this.valid = builder.valid;
+        this.jndiName = builder.jndiName;
+
+        Objects.requireNonNull( name );
+        Objects.requireNonNull( jndiName );
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public long getHops() {
+        return hops;
+    }
+
+    public boolean isValid() {
+        return valid;
+    }
+
+    public String getJndiName() {
+        return jndiName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        Service service = (Service) o;
+        return hops == service.hops && valid == service.valid && Objects.equals(name, service.name) && Objects.equals(jndiName, service.jndiName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, hops, valid, jndiName);
+    }
+
+    @Override
+    public String toString() {
+        return "Service{" +
+                "name='" + name + '\'' +
+                ", hops=" + hops +
+                ", valid=" + valid +
+                ", jndiName='" + jndiName + '\'' +
+                '}';
+    }
+
+    public static class Builder {
+        private String name;
+        private long hops = 0; // 0 == inbound service
+        private boolean valid = false;
+        private String jndiName = "";
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder hops(long hops) {
+            this.hops = hops;
+            return this;
+        }
+
+        public Builder valid(boolean valid) {
+            this.valid = valid;
+            return this;
+        }
+
+        public Builder jndiName(String jndiName) {
+            this.jndiName = jndiName;
+            return this;
+        }
+
+        public Service build() {
+            return new Service(this);
+        }
+    }
+}

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/info/CasualInfoImpl.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/info/CasualInfoImpl.java
@@ -1,55 +1,29 @@
+/*
+ * Copyright (c) 2026, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
 package se.laz.casual.connection.caller.info;
 
 import jakarta.ejb.Remote;
 import jakarta.ejb.Stateless;
 import jakarta.inject.Inject;
-import se.laz.casual.connection.caller.Cache;
-import se.laz.casual.connection.caller.ConnectionFactoriesByPriority;
 import se.laz.casual.connection.caller.ConnectionFactoryLookup;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.logging.Logger;
 
 @Remote(CasualInfo.class)
 @Stateless
-public class CasualInfoImpl implements CasualInfo
-{
-    private static final Logger LOG = Logger.getLogger(CasualInfoImpl.class.getName());
+public class CasualInfoImpl implements CasualInfo {
 
-    Cache cache;
     ConnectionFactoryLookup connectionFactoryLookup;
 
     @Inject
-    public CasualInfoImpl(Cache cache, ConnectionFactoryLookup connectionFactoryLookup) {
-        this.cache = cache;
+    public CasualInfoImpl(ConnectionFactoryLookup connectionFactoryLookup) {
         this.connectionFactoryLookup = connectionFactoryLookup;
     }
 
     @Override
-    public List<Service> getServices() {
-        List<Service> services = new ArrayList<>();
-        // Get all cached service names
-        cache.getServices().forEach(service -> {
-            // For a specific service, multiple connections can occur
-            ConnectionFactoriesByPriority connectionFactoriesByPriority = cache.get(service);
-            // Each connection has a priority, which also represents the number of hops to the service
-            connectionFactoriesByPriority.getOrderedKeys().forEach(priority -> {
-                // For each connection, add a service entry
-                connectionFactoriesByPriority.getForPriority(priority).forEach(connectionFactoryEntry ->
-                        services.add(new Service.Builder().name(service)
-                                .hops(priority)
-                                .jndiName(connectionFactoryEntry.getJndiName())
-                                .valid(connectionFactoryEntry.isValid()).build()));
-            });
-
-        });
-        return services;
-    }
-
-    @Override
-    public void discoverService(String serviceName)
-    {
+    public void discoverService(String serviceName) {
         // Trigger discovery on service (save connections to cache)
         connectionFactoryLookup.get(serviceName);
     }

--- a/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/info/CasualInfoImpl.java
+++ b/casual/casual-caller/src/main/java/se/laz/casual/connection/caller/info/CasualInfoImpl.java
@@ -1,0 +1,56 @@
+package se.laz.casual.connection.caller.info;
+
+import jakarta.ejb.Remote;
+import jakarta.ejb.Stateless;
+import jakarta.inject.Inject;
+import se.laz.casual.connection.caller.Cache;
+import se.laz.casual.connection.caller.ConnectionFactoriesByPriority;
+import se.laz.casual.connection.caller.ConnectionFactoryLookup;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+@Remote(CasualInfo.class)
+@Stateless
+public class CasualInfoImpl implements CasualInfo
+{
+    private static final Logger LOG = Logger.getLogger(CasualInfoImpl.class.getName());
+
+    Cache cache;
+    ConnectionFactoryLookup connectionFactoryLookup;
+
+    @Inject
+    public CasualInfoImpl(Cache cache, ConnectionFactoryLookup connectionFactoryLookup) {
+        this.cache = cache;
+        this.connectionFactoryLookup = connectionFactoryLookup;
+    }
+
+    @Override
+    public List<Service> getServices() {
+        List<Service> services = new ArrayList<>();
+        // Get all cached service names
+        cache.getServices().forEach(service -> {
+            // For a specific service, multiple connections can occur
+            ConnectionFactoriesByPriority connectionFactoriesByPriority = cache.get(service);
+            // Each connection has a priority, which also represents the number of hops to the service
+            connectionFactoriesByPriority.getOrderedKeys().forEach(priority -> {
+                // For each connection, add a service entry
+                connectionFactoriesByPriority.getForPriority(priority).forEach(connectionFactoryEntry ->
+                        services.add(new Service.Builder().name(service)
+                                .hops(priority)
+                                .jndiName(connectionFactoryEntry.getJndiName())
+                                .valid(connectionFactoryEntry.isValid()).build()));
+            });
+
+        });
+        return services;
+    }
+
+    @Override
+    public void discoverService(String serviceName)
+    {
+        // Trigger discovery on service (save connections to cache)
+        connectionFactoryLookup.get(serviceName);
+    }
+}

--- a/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/info/CasualInfoImplTest.groovy
+++ b/casual/casual-caller/src/test/groovy/se/laz/casual/connection/caller/info/CasualInfoImplTest.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
+package se.laz.casual.connection.caller.info
+
+import se.laz.casual.connection.caller.Cache
+import se.laz.casual.connection.caller.ConnectionFactoriesByPriority
+import se.laz.casual.connection.caller.ConnectionFactoryEntry
+import se.laz.casual.connection.caller.ConnectionFactoryLookup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class CasualInfoImplTest extends Specification
+{
+   private String serviceName = "test"
+
+   @Shared
+   Cache cache
+   @Shared
+   ConnectionFactoryLookup connectionFactoryLookup
+   @Shared
+   CasualInfo casualInfo
+
+   def setup()
+   {
+      cache =  Mock(Cache)
+      connectionFactoryLookup = Mock(ConnectionFactoryLookup)
+      casualInfo = new CasualInfoImpl(cache, connectionFactoryLookup)
+   }
+
+   def 'test getServices'()
+   {
+      setup:
+      ConnectionFactoryEntry connectionFactoryEntry = Mock(ConnectionFactoryEntry) {
+         1 * getJndiName() >> { return "jndi" }
+         1 * isValid() >> { return true }
+      }
+
+      ConnectionFactoriesByPriority connectionFactoriesByPriority = Mock(ConnectionFactoriesByPriority) {
+         1 * getOrderedKeys() >> { List.of(Long.valueOf(0))}
+         1 * getForPriority(0) >> {
+            return List.of(connectionFactoryEntry)
+         }
+      }
+      cache.getServices() >> { List.of(serviceName)}
+      cache.get(serviceName) >> connectionFactoriesByPriority
+
+      when:
+      def services = casualInfo.getServices()
+
+      then:
+      services.size() == 1
+      services.get(0).name == serviceName
+      services.get(0).jndiName == "jndi"
+      services.get(0).hops == 0
+      services.get(0).valid
+   }
+}

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '3.3.2'
+version = '3.4.0-SNAPSHOT'
 
 def casual_jca_version = '3.3.0'
 def gson_version = '2.11.0'


### PR DESCRIPTION
Added EJB for easy access to information about casual caller and discovered services/queues and other information. Its main consumer is the casual-java cli.

Added functionality to list services from casual-caller cache.